### PR TITLE
Initial pass at /v2/commerce/transactions

### DIFF
--- a/v2/commerce/transactions/transactions.js
+++ b/v2/commerce/transactions/transactions.js
@@ -17,8 +17,6 @@
 
 // GET /v2/commerce/transactions/current/buys
 // GET /v2/commerce/transactions/current/sells
-// GET /v2/commerce/transactions/history/buys
-// GET /v2/commerce/transactions/history/sells
 
 [
 	{
@@ -36,4 +34,96 @@
 		created: "2014-12-15T14:43:35+00:00"
 	},
 	...
+]
+
+// GET /v2/commerce/transactions/history/buys
+// GET /v2/commerce/transactions/history/sells
+
+[
+	{
+		id: 1000,
+		item_id: 19699,
+		price: 1004,
+		quantity: 20,
+		created: "2014-12-15T14:59:38+00:00",
+		purchased: "2014-12-15T14:59:39+00:00"
+	},
+	{
+		id: 999,
+		item_id: 19699,
+		price: 1003,
+		quantity: 20,
+		created: "2014-12-15T14:59:36+00:00",
+		purchased: "2014-12-15T14:59:37+00:00"
+	}
+	...
+]
+
+
+// Example transaction flow: buying an item.
+// Initial state: no pending orders:
+// GET /v2/commerce/transactions/current/buys
+[]
+
+// GET /v2/commerce/transactions/history/buys
+[]
+
+// List a buy order for something.
+// GET /v2/commerce/transactions/current/buys
+[
+	{
+		id : 42,
+		item_id : 12138,
+		price : 1002,
+		quantity: 100,
+		created: "2014-12-15T14:59:36+00:00"
+	}
+]
+
+// Someone sells you some butter.
+// GET /v2/commerce/transactions/current/buys
+[
+	{
+		id : 42,
+		item_id : 12138,
+		price : 1002,
+		quantity: 92,
+		created: "2014-12-15T14:59:36+00:00"
+	}
+]
+
+// GET /v2/commerce/transactions/history/buys
+[
+	{
+		id : 103,
+		item_id : 12138,
+		price : 1002,
+		quantity: 8,
+		created: "2014-12-15T14:59:36+00:00"
+		purchased: "2014-12-15T15:59:36+00:00"
+	}
+]
+
+// Then someone sells you the rest.
+// GET /v2/commerce/transactions/current/buys
+[]
+
+// GET /v2/commerce/transactions/history/buys
+[
+	{
+		id : 112,
+		item_id : 12138,
+		price : 1002,
+		quantity: 92,
+		created: "2014-12-15T14:59:36+00:00"
+		purchased: "2014-12-15T15:05:00+00:00"
+	},
+	{
+		id : 103,
+		item_id : 12138,
+		price : 1002,
+		quantity: 8,
+		created: "2014-12-15T14:59:36+00:00"
+		purchased: "2014-12-15T15:59:36+00:00"
+	}
 ]

--- a/v2/commerce/transactions/transactions.js
+++ b/v2/commerce/transactions/transactions.js
@@ -1,0 +1,39 @@
+// GET /v2/commerce/transactions
+// Authorization: Bearer access-token
+// NOTE: requires 'account' and 'tradingpost' scopes.
+
+[
+	"current",
+	"history"
+]
+
+// GET /v2/commerce/transactions/current
+// GET /v2/commerce/transactions/history
+
+[
+	"buys",
+	"sells"
+]
+
+// GET /v2/commerce/transactions/current/buys
+// GET /v2/commerce/transactions/current/sells
+// GET /v2/commerce/transactions/history/buys
+// GET /v2/commerce/transactions/history/sells
+
+[
+	{
+		id: 1999,
+		item_id: 19699,
+		price: 1004,
+		quantity: 20,
+		created: "2014-12-15T14:43:36+00:00"
+	},
+	{
+		id: 1997,
+		item_id: 19699,
+		price: 1003,
+		quantity: 20,
+		created: "2014-12-15T14:43:35+00:00"
+	},
+	...
+]


### PR DESCRIPTION
`/v2/commerce/transactions` is a proposed authenticated endpoint to export a user's Black Lion Trading Post transaction data (e.g., the stuff in the "My Transactions" tab in-game). Since it uses the same backend as the in-game UI, it suffers from the same data retention problems -- at some point old data is purged from our systems (maybe 3 months?). This endpoint would allow 3rd party services to export and retain a user's transaction data.

It includes four distinct endpoints which all have the same response format:

 * `/v2/commerce/transactions/current/buys`
 * `/v2/commerce/transactions/current/sells`
 * `/v2/commerce/transactions/history/buys`
 * `/v2/commerce/transactions/history/sells`

These all do what they say on the tin. It's important to note that these endpoints are not bulk-expandable (i.e., they don't accept an `id`/`ids` parameter), but they *are* paginated and provide the appropriate response headers (e.g., `Link`, `X-Result-Count`, `X-Result-Total`, `X-Page-Size`, `X-Page-Total`).