### PR TITLE
proposal for /v2/wvw/matches

### DIFF
--- a/v2/wvw/match_details.js
+++ b/v2/wvw/match_details.js
@@ -1,0 +1,277 @@
+// GET /v2/wvw/match_details/2/8
+{
+  "match": {
+    // match_id could be safely dropped
+    "id": "2-8",
+    "region": 2,
+    "tier": 8
+  },
+
+  // time of last db update
+  "lastupdate": 1391927044,
+
+  // time of next score tick
+  "score_tick": 1391929000,
+
+  // colors should be ALWAYS green/blue/red
+  // according to the ingame rank order
+  // if so, this could be changed to an array:
+  // "maps": [2005, 2006, 2004],
+  // probably unnessecary if "id" is present for worlds/color
+  // however, it's convinient
+  "maps": {
+    "GreenHome": 2005,
+    "BlueHome": 2006,
+    "RedHome": 2004
+  },
+  "worlds": {
+    "red": {
+
+      // see "maps" comment
+      "id": 2004,
+
+      // last flip time for bloodlust possible?
+      "bloodlust": ["RedHome"],
+      "objectives": {
+        "camp": [
+
+          // each of these arrays could also carry the timestamp of the last flip
+          [39, ""],
+          [50, ""],
+          [51, "A7A5885B-B93D-4929-A196-ACDA578CF3DF"],
+          [52, ""],
+          [53, ""],
+          [5, ""],
+          [6, "A7A5885B-B93D-4929-A196-ACDA578CF3DF"]
+        ],
+        "castle": [],
+        "keep": [
+          [33, ""],
+          [37, "8E0F7987-559F-4C5D-A946-572868C4A649"],
+          [1, ""]
+        ],
+        "ruin": [],
+        "tower": [
+          [35, ""],
+          [36, ""],
+          [38, ""],
+          [40, ""],
+          [17, ""],
+          [20, ""]
+        ]
+      },
+      "scores": {
+        "BlueHome": {
+          "score": 5760,
+          "income": 0,
+          "camp": 0,
+          "tower": 0,
+          "keep": 0,
+          "castle": 0
+        },
+        "GreenHome": {
+          "score": 1252,
+          "income": 0,
+          "camp": 0,
+          "tower": 0,
+          "keep": 0,
+          "castle": 0
+        },
+        "RedHome": {
+          "score": 14432,
+          "income": 115,
+          "camp": 5,
+          "tower": 4,
+          "keep": 2,
+          "castle": 0
+        },
+        "Center": {
+          "score": 11410,
+          "income": 55,
+          "camp": 2,
+          "tower": 2,
+          "keep": 1,
+          "castle": 0
+        },
+        "Total": {
+          "score": 32854,
+          "income": 170,
+          "camp": 7,
+          "tower": 6,
+          "keep": 3,
+          "castle": 0
+        }
+      }
+    },
+    "blue": {
+      "id": 2006,
+      "bloodlust": ["BlueHome"],
+      "objectives": {
+        "camp": [
+          [34, ""],
+          [24, ""],
+          [29, ""],
+          [58, ""],
+          [59, ""],
+          [60, "C9734CA4-18C4-46D9-9257-D2FAD663F284"],
+          [61, ""],
+          [4, ""],
+          [7, ""],
+          [8, ""]
+        ],
+        "castle": [],
+        "keep": [
+          [41, "C9734CA4-18C4-46D9-9257-D2FAD663F284"],
+          [44, ""],
+          [46, ""],
+          [23, ""],
+          [27, ""],
+          [2, ""],
+          [3, ""]
+        ],
+        "ruin": [],
+        "tower": [
+          [28, ""],
+          [30, ""],
+          [11, ""],
+          [12, ""],
+          [13, ""],
+          [14, ""],
+          [15, ""],
+          [16, ""],
+          [18, ""],
+          [19, ""],
+          [21, ""],
+          [22, "E2AA7205-CA86-E311-88E3-AC162DC0E835"]
+        ]
+      },
+      "scores": {
+        "BlueHome": {
+          "score": 11474,
+          "income": 100,
+          "camp": 6,
+          "tower": 2,
+          "keep": 2,
+          "castle": 0
+        },
+        "GreenHome": {
+          "score": 2249,
+          "income": 75,
+          "camp": 0,
+          "tower": 0,
+          "keep": 3,
+          "castle": 0
+        },
+        "RedHome": {
+          "score": 3498,
+          "income": 5,
+          "camp": 1,
+          "tower": 0,
+          "keep": 0,
+          "castle": 0
+        },
+        "Center": {
+          "score": 15871,
+          "income": 165,
+          "camp": 3,
+          "tower": 10,
+          "keep": 2,
+          "castle": 0
+        },
+        "Total": {
+          "score": 33092,
+          "income": 345,
+          "camp": 10,
+          "tower": 12,
+          "keep": 7,
+          "castle": 0
+        }
+      }
+    },
+    "green": {
+      "id": 2005,
+      "bloodlust": ["GreenHome"],
+      "objectives": {
+        "camp": [
+          [43, ""],
+          [48, ""],
+          [49, ""],
+          [54, ""],
+          [55, ""],
+          [56, "855AE56B-44DA-4003-9D2C-138C2AB6BC8C"],
+          [10, ""]
+        ],
+        "castle": [
+          [9, "992EFB48-7773-4E96-9C8F-5C34A216BA8C"]
+        ],
+        "keep": [
+          [32, ""],
+          [31, "8EDE7026-2791-4237-B0CE-C41C2EF0AEF1"]
+        ],
+        "ruin": [],
+        "tower": [
+          [42, ""],
+          [45, ""],
+          [47, ""],
+          [57, "490332E4-C14A-427E-9384-E1459362AE99"],
+          [25, ""],
+          [26, ""]
+        ]
+      },
+      "scores": {
+        "BlueHome": {
+          "score": 10383,
+          "income": 45,
+          "camp": 0,
+          "tower": 2,
+          "keep": 1,
+          "castle": 0
+        },
+        "GreenHome": {
+          "score": 25551,
+          "income": 70,
+          "camp": 6,
+          "tower": 4,
+          "keep": 0,
+          "castle": 0
+        },
+        "RedHome": {
+          "score": 9869,
+          "income": 25,
+          "camp": 0,
+          "tower": 0,
+          "keep": 1,
+          "castle": 0
+        },
+        "Center": {
+          "score": 21063,
+          "income": 40,
+          "camp": 1,
+          "tower": 0,
+          "keep": 0,
+          "castle": 1
+        },
+        "Total": {
+          "score": 66866,
+          "income": 180,
+          "camp": 7,
+          "tower": 6,
+          "keep": 2,
+          "castle": 1
+        }
+      }
+    },
+    "neutral": {
+      "bloodlust": [],
+      "objectives": {
+        "camp": [],
+        "castle": [],
+        "keep": [],
+        // i wonder if the last flip time for ruins is nessecary at all
+        // if so, these items should be array ofc
+        "ruin": [62, 63, 64, 65, 66, 72, 73, 74, 75, 76, 67, 68, 69, 70, 71],
+        "tower": []
+      }
+    }
+  }
+}

--- a/v2/wvw/matches.js
+++ b/v2/wvw/matches.js
@@ -1,0 +1,45 @@
+{
+  // the regions part could be dropped, should be part of the docs
+  "regions": {
+    "1": "NA",
+    "2": "EU"
+  },
+
+  // colors should be ALWAYS green/blue/red
+  // according to the ingame rank order
+  // if so, this part could also be dropped
+  "colors": ["green", "blue", "red"],
+
+  // start times for each region
+  // iterator -> region
+  "times": {
+    "1": [1391821200, 1392426000],
+    "2": [1391796000, 1392400800]
+  },
+
+  // no surprise here
+  "matches": {
+    "1": {
+      //iterator -> match tier
+      "1": [1019, 1008, 1013],
+      "2": [1016, 1017, 1009],
+      "3": [1005, 1011, 1002],
+      "4": [1003, 1021, 1015],
+      "5": [1004, 1014, 1010],
+      "6": [1012, 1018, 1020],
+      "7": [1024, 1007, 1001],
+      "8": [1022, 1006, 1023]
+    },
+    "2": {
+      "1": [2104, 2010, 2203],
+      "2": [2201, 2202, 2301],
+      "3": [2013, 2012, 2103],
+      "4": [2204, 2101, 2014],
+      "5": [2007, 2002, 2205],
+      "6": [2003, 2206, 2102],
+      "7": [2207, 2009, 2105],
+      "8": [2006, 2005, 2004],
+      "9": [2011, 2001, 2008]
+    }
+  }
+}

--- a/v2/wvw/objectives.js
+++ b/v2/wvw/objectives.js
@@ -1,0 +1,22 @@
+{
+  // iterator -> objective_id
+  "1": {
+
+    // score and type are mutually interchangable
+    "score": 25,
+    "type": "keep",
+
+    // absolute coordinates of the marker icon
+    "coords": [10766, 13656],
+
+    // i prefer having all languages with one request
+    // a little more overhead is still faster than x requests
+    // where most of the response is the same anyway
+    "name": {
+      "de": "Aussichtspunkt",
+      "en": "Overlook",
+      "es": "Mirador",
+      "fr": "Belvédère"
+    }
+  }
+}

--- a/v2/wvw/world_names.js
+++ b/v2/wvw/world_names.js
@@ -1,0 +1,9 @@
+{
+  // iterator -> world_id
+  "2005": {
+    "de": "Feuerring",
+    "en": "Ring of Fire",
+    "es": "Anillo de Fuego",
+    "fr": "Cercle de feu"
+  }
+}


### PR DESCRIPTION
So here's my proposal for the matches.json as per this wall of text: https://forum-en.guildwars2.com/forum/community/api/API-Suggestion-World-vs-World/3610535 (+following)

In summary:
* direct access to any matchup (no more loop through)
* UNIX timestamps
* > 2kb smaller in size compared to the v1 response

Ok, since i've messed up this pull request, i'm going to throw in the other wvw proposals:

match_details.json:
* complete overhaul
* detailed scores and objective stats for each map
* objectives in neutral state
```
    // GET /v2/wvw/match_details?ids=all 
    // GET /v2/wvw/match_details/2
    // GET /v2/wvw/match_details/2/6
    // GET /v2/wvw/match_details/2/6/red <-- overkill?
```
objectives.json:
* direct access to each objective
* names for each language
* map coordinates

world_names.json:
* direct access to each name
* names for each language