### PR TITLE
RFC: /v2/commerce/history

### DIFF
--- a/v2/commerce/history.js
+++ b/v2/commerce/history.js
@@ -11,7 +11,7 @@
   "buy_price" : { "min" : 40, "max" : 45, "mean" : 41 },
   "sell_price" : { "min" : 48, "max" : 58, "mean ": 55 },
   "demand" : { "min" : 632389, "max": 682697, "mean": 669853 },
-  "supply" : { "min" : 463243, "max": 478633, "mean: 464963 },
+  "supply" : { "min" : 463243, "max": 478633, "mean": 464963 },
   "bought" : 263749,
   "sold" : 361424
 }

--- a/v2/commerce/history.js
+++ b/v2/commerce/history.js
@@ -2,24 +2,24 @@
 // Batch expandable list of item ids with transaction histories.
 
 // GET /v2/commerce/history/19723?time="2015-12-20 14:15:02 UTC"
-// GET /v2/commerce/history?id=19723&time="2015-12-20 14:15:02 UTC"
+// GET /v2/commerce/history?ids=19723&time="2015-12-20 14:15:02 UTC"
 // Statistics for the requested time and item:
 {
-  "i" : 19723,
+  "id" : 19723,
   "start_time" : "2015-12-20 14:00:00 UTC",
   "end_time" : "2015-12-20 14:59:59 UTC",
-  "buy_price" : "min": 40, "max": 45, "mean": 41},
-  "sell_price" : { "min": 48, "max": 58, "mean": 55},
-  "demand" : { "min": , “max”: xxx, “mean”: xxx },
-  "supply" : { "min": 463243, “max”: 478633, “mean”: 464963 },
+  "buy_price" : { "min" : 40, "max" : 45, "mean" : 41 },
+  "sell_price" : { "min" : 48, "max" : 58, "mean ": 55 },
+  "demand" : { "min" : 632389, "max": 682697, "mean": 669853 },
+  "supply" : { "min" : 463243, "max": 478633, "mean: 464963 },
   "bought" : 263749,
   "sold" : 361424
 }
 
-// Alternate specification
-// GET /v2/commerce/history/19723?start_time="2014-12-20 14:15:02 UTC"&end_time="2015-2-16 9:23:28 UTC"
-// GET /v2/commerce/history?id=19723&start_time="2014-12-20 14:15:02 UTC"&end_time="2015-2-16 9:23:28 UTC"
+// Alternate specification:
 // Returns a batch of all statistical summaries in the specified range.
+// GET /v2/commerce/history/19723?start_time="2014-12-20 14:15:02 UTC"&end_time="2015-2-16 9:23:28 UTC"
+// GET /v2/commerce/history?ids=19723&start_time="2014-12-20 14:15:02 UTC"&end_time="2015-2-16 9:23:28 UTC"
 
 // Update jobs
 // Hourly: Iterate transactions for the previous hour's calculating statistics.

--- a/v2/commerce/history.js
+++ b/v2/commerce/history.js
@@ -1,0 +1,27 @@
+// GET /v2/commerce/history
+// Batch expandable list of item ids with transaction histories.
+
+// GET /v2/commerce/history/19723?time="2015-12-20 14:15:02 UTC"
+// GET /v2/commerce/history?id=19723&time="2015-12-20 14:15:02 UTC"
+// Statistics for the requested time and item:
+{
+  "i" : 19723,
+  "start_time" : "2015-12-20 14:00:00 UTC",
+  "end_time" : "2015-12-20 14:59:59 UTC",
+  "buy_price" : "min": 40, "max": 45, "mean": 41},
+  "sell_price" : { "min": 48, "max": 58, "mean": 55},
+  "demand" : { "min": , “max”: xxx, “mean”: xxx },
+  "supply" : { "min": 463243, “max”: 478633, “mean”: 464963 },
+  "bought" : 263749,
+  "sold" : 361424
+}
+
+// Alternate specification
+// GET /v2/commerce/history/19723?start_time="2014-12-20 14:15:02 UTC"&end_time="2015-2-16 9:23:28 UTC"
+// GET /v2/commerce/history?id=19723&start_time="2014-12-20 14:15:02 UTC"&end_time="2015-2-16 9:23:28 UTC"
+// Returns a batch of all statistical summaries in the specified range.
+
+// Update jobs
+// Hourly: Iterate transactions for the previous hour's calculating statistics.
+// Daily: Merge hourly summaries for the 32nd previous day into a daily summary.
+// Weekly: Merge daily summaries for the 53rd previous week into a weekly summary.


### PR DESCRIPTION
### Summary

This RFC adds historical data as well as buy / sell quantity information to the Guild Wars 2 commerce API. While serving a complete transaction history for all items from the trading post is understandably impractical, a statistical summary of the transactions may be feasible.

### Motivation

Historical data regarding trading post activity is is currently unavailable through the current API, and applications that wish to display this information in plots, etc. must currently scrape the existing commerce endpoints to build their own databases, which can only provide data from when the scrapes begin and can result in incomplete data due to network outages, server uptime, etc. This approach is also sensitive to sampling errors due to high frequency fluctuations in strongly demanded items. Adding summaries of this data to the API would allow these applications to make fewer calls against the existing APIs to update their local caches, and allow them to import data from before the services became active.

Additionally, the number of items actually bought and sold are invaluable pieces of information for various types of analysis, and this information cannot currently be obtained in any accurate fashion. The best way to approximate this information using the current API is to take the differences in supply and demand between scrapes. This approach is subject to inaccuracies from sampling artifacts and misinterprets buy/sell orders that have been removed as completed, rather than aborted, transactions.

Providing this information would add much greater depth to the market data available through the Guild Wars 2 API without incurring the storage and computational expenses associated with serving individual transactions.

### Implementation

This approach would require hourly, daily, and monthly jobs to produce / condense the summaries.

The hourly job would iterate through the transaction logs to produce a summary of the previous hour's market activity, while the daily and monthly jobs would condense the summaries older than one month or one year, respectively.

The summaries will include the following statistics, calculated as described:

Buy and sell price minima, maxima, and means for each item. In pseudocode,

    // Calculate price statistics for the last hour.
    // If no transactions, just use current listing/order price.
    minPrice = lastHourTransactionLog.first().price
    maxPrice = lastHourTransactionLog.first().price
    meanPrice = 0
    for transaction in lastHourTransactionLog:
      minPrice = min(transaction.price, minPrice)
      maxPrice = max(transaction.price, maxPrice)
      meanPrice += transaction.price * transaction.millisecondsToNextTransaction()
    meanPrice /= 1000 * 60 * 60 // ms per hour

The same pattern would be used for supply and demand quantites. Buy and sell quantities are simply summations of all transaction quantities.

The hourly and daily summaries can be merged into daily and weekly summaries by simply taking the min/max of the individual mins/maxes, averaging the temporal means, and summing the buy/sell quantities.