### PR TITLE
Initial pass at /v2/materials and /v2/account/materials

### DIFF
--- a/v2/account/materials.js
+++ b/v2/account/materials.js
@@ -1,0 +1,34 @@
+// GET /v2/account/materials
+// Authorization: Bearer oauth2-token
+// Requires "account" and "inventories" scopes.
+[
+	{
+		"id" : 19699,
+		"type" : "common",
+		"count" : 250
+	},
+	{
+		"id" : 19670,
+		"type" : "common",
+		"count" : 0
+	},
+	{
+		"id" : 234,
+		"type" : "fine",
+		"count" : 3
+	}
+]
+// Where "type" is one of:
+//
+//  * "common"
+//  * "fine"
+//  * "rare"
+//  * "ascended"
+//  * "jewels"
+//  * "cooking"
+//  * "festive"
+//
+// And indicates the category the material is stored in.
+//
+// Array index indicates the slot; empty slots are indicated 
+// with count=0.

--- a/v2/account/materials.js
+++ b/v2/account/materials.js
@@ -4,31 +4,26 @@
 [
 	{
 		"id" : 19699,
-		"type" : "common",
+		"category" : 5,
 		"count" : 250
 	},
 	{
 		"id" : 19670,
-		"type" : "common",
+		"category" : 5,
 		"count" : 0
 	},
 	{
 		"id" : 234,
-		"type" : "fine",
+		"category" : 4,
 		"count" : 3
-	}
+	},
+	...
 ]
-// Where "type" is one of:
-//
-//  * "common"
-//  * "fine"
-//  * "rare"
-//  * "ascended"
-//  * "jewels"
-//  * "cooking"
-//  * "festive"
-//
-// And indicates the category the material is stored in.
+// Where "category" refers to an id fetchable via /v2/materials.
+// Note that you can just grab all of the categories via
+// /v2/materials?ids=all (in the language of your choice) so
+// it's not a terrible number of round-trips.
 //
 // Array index indicates the slot; empty slots are indicated 
-// with count=0.
+// with count=0. They'll still have the "id" to indicate which
+// item id can be stored in them.

--- a/v2/materials.js
+++ b/v2/materials.js
@@ -1,0 +1,34 @@
+// Normal bulk-expanded endpoint that dumps the metadata associated
+// with categories in the account bank's material storage.
+
+// GET /v2/materials
+[ 5, 6, 29, 30, 37, 38 ]
+
+// GET /v2/materials/5
+{
+	id: 5,
+	name: "Cooking Materials",
+	items: [
+		12134,
+		12238,
+		12147,
+		...
+	]
+}
+
+// Also supports the ?lang parameter to get the localized names.
+
+// GET /v2/materials?ids=all&lang=de
+[
+	{
+		id: 5,
+		name: "Zutaten zum Kochen",
+		items: [
+			12134,
+			12238,
+			12147,
+			...
+		]
+	},
+	...
+]


### PR DESCRIPTION
These endpoints expose the items stored in an account's bank in the material storage. It provides an additional unauthenticated endpoint that describes which items can be stored and the category headings. These changes are largely based (and forked off from) the discussion in #3.