### PR TITLE
Add a FOV field to the mumble link's identity blob

### DIFF
--- a/mumble.md
+++ b/mumble.md
@@ -7,7 +7,8 @@
 	"map_id": 50,
 	"world_id": 1001,
 	"team_color_id": 0,
-	"commander": false
+	"commander": false,
+	"fov" : 0.873
 }
 // Where profession values have the following mapping:
 //


### PR DESCRIPTION
Basically what it says on the tin.

Note that this is a proposed potentially breaking change -- please let me know if this will cause issues with any existing applications (Mumble scripts or otherwise). This really isn't the right place to put the FOV, but the Mumble link data structure is exceptionally limited and this is the only place that won't break everything horribly. Eventually one day in the far-flung future I'd like to have a better transport for this data, but for now this is what we've got.

If this will break your applications/integrations/anything, please comment. I really don't like breaking things.