### PR TITLE
Add list of guild ids to /v2/account

### DIFF
--- a/v2/account/account.js
+++ b/v2/account/account.js
@@ -2,7 +2,12 @@
 // Authorization: Bearer oauth2-token
 // Requires "account" scope.
 {
-	"id"    : "account-guid",
-	"name"  : "Lawton.1234",
-	"world" : 1007
+	"id"     : "account-guid",
+	"name"   : "Lawton.1234",
+	"world"  : 1007,
+	"guilds" : [
+		"DA9137CD-3A86-E411-B57A-00224D566B58",
+		"1F5F70AA-1DB6-E411-A2C4-00224D566B58",
+		"8B211747-3B86-E411-B57A-00224D566B58"
+	]
 }


### PR DESCRIPTION
This field contains the list of all guilds the account is currently a
member of; they can be resolved against `/v1/guild_details.json` to get
e.g., the guild names.

This is a pretty straightforward change, but it required some backend modifications that might take a month to propagate through our release process (sorry!).