### PR TITLE
proposal for /v2/achievements

### DIFF
--- a/v2/achievements/achievements.js
+++ b/v2/achievements/achievements.js
@@ -1,0 +1,75 @@
+// GET /v2/achievements
+[
+    {
+        "id" : 1,
+        "type" : "achievement",
+        "title" : "If We Only Had Marshmallows",
+        "description" : "At least you'll be warm.",
+        "hint" : "Your team lit every bonfire in Snowblind fractal inside the Fractals of the Mists.",
+        "related_maps": [123], // for those with location hints, map ids
+        "category": 2,
+        "tiers":
+            [
+                {
+                    "tier": 1,
+                    "threshold": 1, // amount of objectives that must be reached
+                    "points": 5
+                }
+            ],
+        "objective_count": 1 // "1" for directly unlockable achievements such as skill based achievements
+    },
+    {
+        "id" : 2,
+        "type" : "achievement",
+        "title" : "Dungeon Master",
+        "description" : "Mastering the deepest secrets of the darkest corners.",
+        "hint" : "Complete 8 explorable dungeons.",
+        "category": 3,
+        "tiers":
+            [
+                {
+                    "tier": 1,
+                    "threshold": 3,
+                    "points": 10
+                }
+            ],
+        "rewards":
+        {
+            "title": "Dungeon Master"
+        },
+        "objective_count": 3, // in this case the count of achievements that must be unlocked
+        "achievement_ids": [3,4,5]
+    },
+    {
+        "id" : 3,
+        "type" : "collection",
+        "title" : "Luminescent Gloves",
+        "description" : "Mastering the deepest secrets of the darkest corners.",
+        "hint" : "Collect the 10 parts required to assemble Luminescent Gloves.",
+        "category": 5,
+        "tiers":
+            [
+                {
+                    "tier": 1,
+                    "threshold": 1,
+                    "points": 1
+                },
+                {
+                    "tier": 2,
+                    "threshold": 5,
+                    "points": 1
+                },
+                {
+                    "tier": 3,
+                    "threshold": 10,
+                    "points": 3
+                }
+            ],
+        "rewards":
+        {
+            "items": [1000] // not sure if there exist achievements with multiple item rewards
+        },
+        "objective_count": 3, // in this case the count of collectables
+        "collectables": [1001,1002,1003] // items that need to be collected
+    }
+]

--- a/v2/achievements/achievements.js
+++ b/v2/achievements/achievements.js
@@ -6,17 +6,17 @@
         "title" : "If We Only Had Marshmallows",
         "description" : "At least you'll be warm.",
         "hint" : "Your team lit every bonfire in Snowblind fractal inside the Fractals of the Mists.",
-        "related_maps": [123], // for those with location hints, map ids
-        "category": 2,
-        "tiers":
+        "related_maps" : [123], // for those with location hints, map ids
+        "category" : 2,
+        "tiers" :
             [
                 {
-                    "tier": 1,
-                    "threshold": 1, // amount of objectives that must be reached
-                    "points": 5
+                    "tier" : 1,
+                    "threshold" : 1, // amount of objectives that must be reached
+                    "points" : 5
                 }
             ],
-        "objective_count": 1 // "1" for directly unlockable achievements such as skill based achievements
+        "objective_count" : 1 // "1" for directly unlockable achievements such as skill based achievements
     },
     {
         "id" : 2,
@@ -24,21 +24,21 @@
         "title" : "Dungeon Master",
         "description" : "Mastering the deepest secrets of the darkest corners.",
         "hint" : "Complete 8 explorable dungeons.",
-        "category": 3,
-        "tiers":
+        "category" : 3,
+        "tiers" :
             [
                 {
-                    "tier": 1,
-                    "threshold": 3,
-                    "points": 10
+                    "tier" : 1,
+                    "threshold" : 3,
+                    "points" : 10
                 }
             ],
-        "rewards":
+        "rewards" :
         {
-            "title": "Dungeon Master"
+            "title" : "Dungeon Master"
         },
-        "objective_count": 3, // in this case the count of achievements that must be unlocked
-        "achievement_ids": [3,4,5]
+        "objective_count" : 3, // in this case the count of achievements that must be unlocked
+        "achievement_ids" : [3,4,5]
     },
     {
         "id" : 3,
@@ -46,30 +46,30 @@
         "title" : "Luminescent Gloves",
         "description" : "Mastering the deepest secrets of the darkest corners.",
         "hint" : "Collect the 10 parts required to assemble Luminescent Gloves.",
-        "category": 5,
-        "tiers":
+        "category" : 5,
+        "tiers" :
             [
                 {
-                    "tier": 1,
-                    "threshold": 1,
-                    "points": 1
+                    "tier" : 1,
+                    "threshold" : 1,
+                    "points" : 1
                 },
                 {
-                    "tier": 2,
-                    "threshold": 5,
-                    "points": 1
+                    "tier" : 2,
+                    "threshold" : 5,
+                    "points" : 1
                 },
                 {
-                    "tier": 3,
-                    "threshold": 10,
-                    "points": 3
+                    "tier" : 3,
+                    "threshold" : 10,
+                    "points" : 3
                 }
             ],
-        "rewards":
+        "rewards" :
         {
-            "items": [1000] // not sure if there exist achievements with multiple item rewards
+            "items" : [1000] // not sure if there exist achievements with multiple item rewards
         },
-        "objective_count": 3, // in this case the count of collectables
-        "collectables": [1001,1002,1003] // items that need to be collected
+        "objective_count" : 3, // in this case the count of collectables
+        "collectables" : [1001,1002,1003] // items that need to be collected
     }
 ]

--- a/v2/achievements/categories.js
+++ b/v2/achievements/categories.js
@@ -12,7 +12,7 @@
                 {
                     "id" : 3,
                     "title" : "Dungeons",
-                    "main_achievement": 2 // used as description of the category and colored in the same color as the category (you may notice it ingame)
+                    "main_achievement" : 2 // used as description of the category and colored in the same color as the category (you may notice it ingame)
                 }
             ]
     }

--- a/v2/achievements/categories.js
+++ b/v2/achievements/categories.js
@@ -1,0 +1,19 @@
+// GET /v2/achievements/categories
+[
+    {
+        "id" : 1,
+        "title" : "General",
+        "subcategories" :
+            [
+                {
+                    "id" : 2,
+                    "title" : "Fractals of the Mists",
+                },
+                {
+                    "id" : 3,
+                    "title" : "Dungeons",
+                    "main_achievement": 2 // used as description of the category and colored in the same color as the category (you may notice it ingame)
+                }
+            ]
+    }
+]


### PR DESCRIPTION
Hi there!

This is a proposal and draft (!) of a potential achievement endpoint.

I'm not sure about the general structure. 
You may prefer API calls like /v2/achievements/category/{category-id}/{achievement-id} (or maybe both? -> /v2/achievements/{achievement-id} while returning a list of achievements when requesting /v2/achievements without parameters) to pull the achievement information. I'm not deep into the formatting style of the API so that basically depends on you and i'm pleased to hear your opinions.

I commented a few things inside the files to make things clearer.

I may also add a proposal for an authenticated endpoint at /v2/account/achievements to request the current progress of a player.