### PR TITLE
Proposal for adding map type to /v2/continents and /v2/maps

### DIFF
--- a/v2/floors/map.js
+++ b/v2/floors/map.js
@@ -1,6 +1,7 @@
 // GET /v2/continents/1/floors/1/regions/1/maps/26
 {
     "name" : "Dredgehaunt Cliffs",
+    "type" : "pve",
     "min_level" : 40,
     "max_level" : 50,
     "default_floor" : 1,
@@ -59,3 +60,52 @@
     },
     "id" : 26
 }
+
+// GET /v2/continents/2/floors/7/regions/6/maps/795
+{
+    "name" : "Legacy of the Foefire",
+    "type" : "pvp",
+    ...
+    "id" : 795
+}
+
+// GET /v2/continents/2/floors/3/regions/7/maps/94
+{
+    "name" : " Borderlands",
+    "type" : "wvw",
+    ...
+    "id" : 94
+}
+
+// GET /v2/continents/1/floors/1/regions/8/maps/733
+{
+    "name" : "Forging the Pact",
+    "type": "personal_story",
+    ...
+    "id" : 733
+}
+
+// GET /v2/continents/1/floors/1/regions/8/maps/1006
+{
+    "name" : "Foefire Cleansing",
+    "type": "living_story",
+    ...
+    "id" : 1006
+}
+
+// GET /v2/continents/1/floors/-10/regions/2/maps/66
+{
+    "name": "Citadel of Flame",
+    "type" : "dungeon_story",
+    ...
+    "id" : 66
+}
+
+// GET /v2/continents/1/floors/-10/regions/2/maps/69
+{
+    "name": "Citadel of Flame",
+    "type" : "dungeon_explorable",
+    ...
+    "id" : 69
+}
+

--- a/v2/maps/maps.js
+++ b/v2/maps/maps.js
@@ -1,0 +1,70 @@
+// GET /v2/maps/26
+{
+    "id" : 26,
+    "name" : "Dredgehaunt Cliffs",
+    "type" : "pve",
+    "min_level" : 40,
+    "max_level" : 50,
+    "default_floor" : 1,
+    "floors" : [ 0, 1, 2 ],
+    "region_id" : 1,
+    "region_name" : "Shiverpeak Mountains",
+    "continent_id" : 1,
+    "continent_name" :" Tyria",
+    "map_rect" : [
+        [ -27648, -36864 ],
+        [ 27648, 39936 ]
+    ],
+    "continent_rect" : [
+        [ 19456, 14976 ],
+        [ 21760, 18176 ]
+    ]
+}
+
+// GET /v2/maps/795
+{
+    "id" : 795,
+    "name" : "Legacy of the Foefire",
+    "type": "pvp",
+    ...
+}
+
+// GET /v2/maps/94
+{
+    "id" : 94,
+    "name" : " Borderlands",
+    "type" : "wvw",
+    ...
+}
+
+// GET /v2/maps/733
+{
+    "id" : 733,
+    "name" : "Forging the Pact",
+    "type": "personal_story",
+    ...
+}
+
+// GET /v2/maps/1006
+{
+    "id" : 1006,
+    "name" : "Foefire Cleansing",
+    "type": "living_story",
+    ...
+}
+
+// GET /v2/maps/66
+{
+    "id": 66,
+    "name": "Citadel of Flame",
+    "type" : "dungeon_story",
+    ...
+}
+
+// GET /v2/maps/69
+{
+    "id": 69,
+    "name": "Citadel of Flame",
+    "type" : "dungeon_explorable",
+    ...
+}


### PR DESCRIPTION
I came up with this idea about a month ago on the forums, but got no response. So I decided to elaborate it further with this PR.

This addition makes our lives easier to separate the various maps ("normal" pve, pvp, wvw, dungeons, story, etc.) without defining a list on our own (that might be changing with updates too!).

Currently, I've compiled the following list of map types:
- pve (for normal pve maps)
- pvp
- wvw
- personal_story
- living_story
- dungeon_story
- dungeon_explorable

I'm pretty sure I missed some. Let me know if you like the idea and if it's actually possible to include it. You do have a way of identifying different maps internally, right? :grinning:

On a side note, I added /v2/maps as well with the current implementation and my addition.
