### PR TITLE
Add inventories/equipment to /v2/characters

### DIFF
--- a/v2/characters/characters.js
+++ b/v2/characters/characters.js
@@ -48,175 +48,88 @@
 	created: "2015-06-05T19:45:00Z",
 	age: 91,
 	deaths: 0
-	equipment: {
-		aquatic_helm: {
-			id: 69091
-		},
-		backpack: {
-			id: 49371,
-			infusions: [
-				49453
-			]
-		},
-		coat: {
-			id: 48085,
-			infusions: [
-				37131
-			]
-		},
-		boots: {
-			id: 48084
-		},
-		gloves: {
-			id: 48086
-		},
-		leggings: {
-			id: 48088
-		},
-		shoulders: {
-			id: 48089
-		},
-		accessory1: {
-			id: 39233
-		},
-		accessory2: {
-			id: 39232
-		},
-		ring1: {
-			id: 37075
-		},
-		ring2: {
-			id: 37086
-		},
-		amulet: {
-			id: 39308
-		},
-		weapon_mainhand_primary: {
-			id: 46771
-		},
-		weapon_offhand_primary: null,
-		weapon_mainhand_secondary: {
-			id: 46760
-		},
-		weapon_offhand_secondary: {
-			id: 46767
-		},
-		aquatic_weapon_primary: null,
-		aquatic_weapon_secondary: null,
-		sickle: {
-			id: 23029
-		},
-		axe: {
-			id: 23030
-		},
-		pick: {
-			id: 23031
-		}
-	},
-	inventory: [
-		null,
-		null,
-		null,
-		null,
+	equipment: [
 		{
-			id: 12138,
-			count: 217
+			id: 6472,
+			slot: "Coat"
 		},
-		null,
 		{
-			id: 626,
-			count: 1,
+			id: 6470,
+			slot: "Boots"
+		},
+		{
+			id: 6549,
+			slot: "Helm"
+		},
+		{
+			id: 6473,
+			slot: "Leggings"
+		},
+		{
+			id: 33345,
+			slot: "WeaponA1"
+		},
+		{
+			id: 49812,
+			slot: "WeaponB1"
 			upgrades: [
-				24797
+				24607,
+				24548
 			]
-		},
-		null,
-		null,
-		{
-			id: 19976,
-			count: 1
-		},
-		{
-			id: 67134,
-			count: 1
-		},
-		{
-			id: 8934,
-			count: 1
-		},
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		null,
-		{
-			id: 12138,
-			count: 33
 		}
 	],
 	bags: [
 		{
 			id: 8941,
 			size: 4
+			inventory: [
+				null,
+				{
+					id: 32134,
+					count: 1
+				},
+				null,
+				null
+			]
 		},
 		null,
 		{
 			id: 8932,
 			size: 20
+			inventory: [
+				null,
+				null,
+				...
+			]
 		},
 		{
 			id: 48715,
 			size: 20
 		},
-		{
-			id: 48715,
-			size: 20
-		}
+		null
 	]
 }
+
+// Possible equipment slots:
+//  * HelmAquatic
+//  * Backpack
+//  * Coat
+//  * Boots
+//  * Gloves
+//  * Helm
+//  * Leggings
+//  * Shoulders
+//  * Accessory1
+//  * Accessory2
+//  * Ring1
+//  * Ring2
+//  * Amulet
+//  * WeaponAquaticA
+//  * WeaponAquaticB
+//  * WeaponA1 (primary mainhand)
+//  * WeaponA2 (primary offhand)
+//  * WeaponB1 (secondary mainhand)
+//  * WeaponB2 (secondary offhand)
+//  * Sickle
+//  * Axe
+//  * Pick


### PR DESCRIPTION
This is a continuation of #16 that adds the equipment/inventory details when the API key has the "inventories" scope. IIRC it roughly follows the recommendations of that thread. It's missing the gathering tools' charges which will be added in a future PR. 