### PR TITLE
Initial pass at /v2/pvp/stats

### DIFF
--- a/v2/pvp/stats.js
+++ b/v2/pvp/stats.js
@@ -3,6 +3,7 @@
 
 [
 	{
+		pvp_rank  : 2,
 		aggregate : {
 			wins       : 1,
 			losses     : 2,

--- a/v2/pvp/stats.js
+++ b/v2/pvp/stats.js
@@ -1,0 +1,46 @@
+// GET /v2/pvp/stats?access_token=token
+// Scopes: account, pvp
+
+[
+	{
+		aggregate : {
+			wins       : 1,
+			losses     : 2,
+			desertions : 0,
+			byes       : 2,
+			forfeits   : 0
+		},
+		professions : {
+			mesmer : {
+				wins       : 0,
+				losses     : 1,
+				desertions : 0,
+				byes       : 1,
+				forfeits   : 0
+			},
+			thief: {
+				wins       : 1,
+				losses     : 1,
+				desertions : 0,
+				byes       : 1,
+				forfeits   : 0
+			}
+		},
+		ladders : {
+			unranked : {
+				wins       : 0,
+				losses     : 1,
+				desertions : 0,
+				byes       : 0,
+				forfeits   : 0
+			},
+			ranked : {
+				wins       : 2,
+				losses     : 1,
+				desertions : 0,
+				byes       : 2,
+				forfeits   : 0
+			}
+		}
+	}
+]


### PR DESCRIPTION
`/v2/pvp/stats` is an authenticated endpoint that's intended to provide aggregated pvp statistics for an account. These are roughly the metrics that are displayed in the in-game PvP panel.

I'm not entirely sold on how `professions`/`ladders` are laid out -- it may make more sense to structure the data differently. I'm also not sure what `forfeits`/`byes` are in the context of PvP -- I suspect they're to do with one team not accepting a popped queue (if that's the case, then those fields will need to be renamed).

AFAIK we don't track per-ladder profession data, that's probably something that should be added too.