### PR TITLE
Add crafting disciplines to /v2/characters

### DIFF
--- a/v2/characters/characters.js
+++ b/v2/characters/characters.js
@@ -15,7 +15,24 @@
 	guild: "1F5F70AA-1DB6-E411-A2C4-00224D566B58",
 	created: "2015-06-05T19:45:00Z",
 	age: 91, // in seconds.
-	deaths: 0
+	deaths: 0,
+	crafting: [
+		{
+			discipline : "Leatherworker",
+			active : true,
+			rating : 500
+		},
+		{
+			discipline : "Cook",
+			active : false,
+			rating : 400
+		},
+		{
+			discipline : "Armorsmith",
+			rating: 423,
+			active : true
+		}
+	]
 }
 
 // GET /v2/characters?page=0
@@ -31,7 +48,14 @@
 		guild: "1F5F70AA-1DB6-E411-A2C4-00224D566B58"
 		created: "2015-06-05T19:45:00Z",
 		age: 91,
-		deaths: 0
+		deaths: 0,
+		crafting: [
+			{
+				discipline : "Cook",
+				rating : 400,
+				active : true
+			}
+		]
 	}
 ]
 


### PR DESCRIPTION
These would be accessible with the `characters` permission -- I don't think there's much need for an additional permission here.

Before anyone asks, recipe unlocks will be a separate PR.