### PR TITLE
Inventory/Bank: changed upgrades and infusions from array to object

### DIFF
--- a/v2/account/bank.js
+++ b/v2/account/bank.js
@@ -8,7 +8,9 @@
 		slot: 1,
 		count: 1,
 		upgrades: [
-			24675
+			{
+				id: 24675
+			}
 		]
 	},
 	{
@@ -24,7 +26,9 @@
 		count: 1,
 		skin: 3706,
 		upgrades: [
-			24661
+			{
+				id: 24661
+			}
 		]
 	},
 	null,
@@ -37,8 +41,13 @@
 		slot: 10,
 		count: 1
 		infusions: [
-			1234,
-			5678
+			{
+				id: 1234
+			},
+			{
+				id: 5678
+			}
+
 		]
 	},
 	{

--- a/v2/account/bank.js
+++ b/v2/account/bank.js
@@ -4,30 +4,30 @@
 [
 	null,
 	{
-		id: 46774,
+		item_id: 46774,
 		slot: 1,
 		count: 1,
 		upgrades: [
 			{
-				id: 24675
+				item_id: 24675
 			}
 		]
 	},
 	{
-		id: 48087,
+		item_id: 48087,
 		slot: 2,
 		count: 1,
-		skin: 89
+		skin_id: 89
 	},
 	null,
 	{
-		id: 46760,
+		item_id: 46760,
 		slot: 4,
 		count: 1,
-		skin: 3706,
+		skin_id: 3706,
 		upgrades: [
 			{
-				id: 24661
+				item_id: 24661
 			}
 		]
 	},
@@ -37,21 +37,21 @@
 	null,
 	null,
 	{
-		id: 19996,
+		item_id: 19996,
 		slot: 10,
 		count: 1
 		infusions: [
 			{
-				id: 1234
+				item_id: 1234
 			},
 			{
-				id: 5678
+				item_id: 5678
 			}
 
 		]
 	},
 	{
-		id: 19976,
+		item_id: 19976,
 		slot: 11,
 		count: 4
 	},

--- a/v2/characters/characters.js
+++ b/v2/characters/characters.js
@@ -71,10 +71,14 @@
 		},
 		{
 			id: 49812,
-			slot: "WeaponB1"
+			slot: "WeaponB1",
 			upgrades: [
-				24607,
-				24548
+				{
+					id: 24607
+				},
+				{
+					id: 24548
+				}
 			]
 		}
 	],

--- a/v2/characters/characters.js
+++ b/v2/characters/characters.js
@@ -50,46 +50,47 @@
 	deaths: 0
 	equipment: [
 		{
-			id: 6472,
+			item_id: 6472,
 			slot: "Coat"
 		},
 		{
-			id: 6470,
+			item_id: 6470,
 			slot: "Boots"
 		},
 		{
-			id: 6549,
+			item_id: 6549,
 			slot: "Helm"
 		},
 		{
-			id: 6473,
+			item_id: 6473,
 			slot: "Leggings"
 		},
 		{
-			id: 33345,
+			item_id: 33345,
 			slot: "WeaponA1"
 		},
 		{
-			id: 49812,
+			item_id: 49812,
+			skin_id: 3706,
 			slot: "WeaponB1",
 			upgrades: [
 				{
-					id: 24607
+					item_id: 24607
 				},
 				{
-					id: 24548
+					item_id: 24548
 				}
 			]
 		}
 	],
 	bags: [
 		{
-			id: 8941,
+			item_id: 8941,
 			size: 4
 			inventory: [
 				null,
 				{
-					id: 32134,
+					item_id: 32134,
 					count: 1
 				},
 				null,
@@ -98,7 +99,7 @@
 		},
 		null,
 		{
-			id: 8932,
+			item_id: 8932,
 			size: 20
 			inventory: [
 				null,
@@ -107,7 +108,7 @@
 			]
 		},
 		{
-			id: 48715,
+			item_id: 48715,
 			size: 20
 		},
 		null


### PR DESCRIPTION
For consistencies sake. This way we can grab all item IDs by recursively searching for the key "id" or for example use functions like [array_column()](http://php.net/manual/function.array-column.php).
