### PR TITLE
Change to v2/floors/sectors.json

### DIFF
--- a/v2/floors/sectors.js
+++ b/v2/floors/sectors.js
@@ -3,5 +3,13 @@
     "name" : "Dostoev Sky Peak",
     "level" : 46,
     "coord" : [ 20564.9, 16726.1 ],
-    "id" : 526
+    "id" : 526,
+
+    // a polyline -> http://leafletjs.com/reference.html#polyline
+    "bounds": [
+        [123, 456],
+        [7890, 1234],
+        [5678, 9012],
+        // ...
+    ]
 }


### PR DESCRIPTION
A feature which has been requested by some wiki editors: sector boundaries as polylines so that we can draw maps like this: http://wiki.guildwars2.com/wiki/File:Queensdale_map.jpg