### PR TITLE
Change to v2/floors/regions.json - added bounds

### DIFF
--- a/v2/floors/region.js
+++ b/v2/floors/region.js
@@ -2,6 +2,14 @@
 {
     "name" : "Shiverpeak Mountains",
     "label_coord" : [ 19840, 13568 ],
+    "map_rect" : [
+        [-27648, -36864 ],
+        [ 27648, 39936 ]
+    ],
+    "continent_rect" : [
+        [ 19456, 14976 ],
+        [ 21760, 18176 ]
+    ],
     "maps" : {
         "26" : {
             "name" : "Dredgehaunt Cliffs",


### PR DESCRIPTION
Pretty much what the commit message says. Theres no real way to draw a whole region and center the map to properly display it.
