### PR TITLE
Create dungeon.js

### DIFF
--- a/v2/account/dungeon.js
+++ b/v2/account/dungeon.js
@@ -1,0 +1,29 @@
+// GET /v2/account/dungeon
+// Authorization: Bearer oauth2-token
+// Requires "account" scope.
+// This exact format should also have an endpoint under character, for
+// determining, e.g., which story mode unlocks are needed per character.
+{
+  "Ascalonian Catacombs": { // Name of dungeon
+    "Story": { // Path id, either "Story" or "Path X". Alternatively, "Hodgins" "Tzaark", etc.
+      "first": "<timestamp>", // Timestamp of when dungeon was first completed.
+      "last": "<timestamp>", // Timestamp of most recent completion.
+      "count": 4 // Total number of times dungeon has been completed.
+    },
+    "Path 1": {
+      "first": ...
+    },
+    ...
+  },
+  "Twilight Arbor": { ... },
+  ...
+  "Fractals Of The Mist": { // Fractals too!
+    "Scale 1:" {
+      "first": ...
+    },
+    ...,
+    "Scale 50": {
+      ...
+    }
+  }
+}


### PR DESCRIPTION
Adds dungeon completion info to /account/, and should also be used under /character/. Extends and replaces #53.

The in-game UI provides no mechanism to know which dungeons have been completed for daily rewards, story mode unlocks, or Dungeon Master (DM) completion. Hopefully the API team and the dev community will fill in this missing functionality.

At a minimum, the 'last completion timestamp' is the most important bit, as that will let us know everything we need to know:

- Have I run this path for DM yet?
- Do I need to unlock story mode on this character?
- Have I already run this since the last reset?