### PR TITLE
changes to the mumble identity

### DIFF
--- a/mumble.md
+++ b/mumble.md
@@ -2,23 +2,14 @@
 // Mumble Link Identity
 // JSON-encoded string with the following fields --
 {
-	"name": "Stabby Mcstabberson",
-	"profession": 5,
-	"map_id": 50,
-	"world_id": 1001,
-	"team_color_id": 0,
-	"commander": false
+    "character_id": "11111111-2222-3333-4444-555555555555",
+    "map_id": 50,
+    "team_color_id": 0,
+    "commander": false,
+    "health": 27586, // questionable, requires realtime updates
+    "supply": 15,
+    ...
 }
-// Where profession values have the following mapping:
-//
-// 1 = Guardian
-// 2 = Warrior
-// 3 = Engineer
-// 4 = Ranger
-// 5 = Thief
-// 6 = Elementalist
-// 7 = Mesmer
-// 8 = Necromancer
 ```
 
 ```c++


### PR DESCRIPTION
The Mumble identity string contains data which became redundant when the ```/v2/characters``` API was introduced. Also, it doesn't comply with the authorized endpoints anymore since the data is available without authorization.
I changed the ```name``` field to ```character_id``` which contains the hopefully soon-to-be-available character UID (https://github.com/arenanet/api-cdi/issues/32). The ```profession``` field is obsolete, ```supply``` added as per https://github.com/arenanet/api-cdi/pull/55#issuecomment-120087134, also added ```health``` which is questionable as Lawton already mentioned [on the forums](https://forum-en.guildwars2.com/forum/community/api/Mumble-Link-Add-player-health/5334686). In addition, the name field in the Link data, which currently contains the account name, should be changed to the account UID.