### PR TITLE
Add population to /v2/worlds.

### DIFF
--- a/v2/worlds.js
+++ b/v2/worlds.js
@@ -1,0 +1,35 @@
+// Normal bulk-expanded endpoint that dumps out the list
+// of GW2 worlds and associated metadata.
+
+// GET /v2/worlds
+[ 1001, 1002, 1003, ... ]
+
+// GET /v2/worlds/1
+{
+	"id": 1001,
+	"name": "Anvil Rock"
+	"population": "Medium"
+}
+
+// GET /v2/worlds?page=0&page_size=3
+// GET /v2/worlds?ids=1001,1002,1003
+[
+	{
+		"id": 1001,
+		"name": "Anvil Rock",
+		"population": "High"
+	},
+	{
+		"id": 1002,
+		"name": "Borlis Pass"
+		"population": "VeryHigh"
+	},
+	{
+		"id": 1003,
+		"name": "Yak's Bend"
+		"population": "Full"
+	}
+
+]
+
+// Population is one of "Low", "Medium", "High", "VeryHigh", "Full".


### PR DESCRIPTION
The world endpoint is old, but wasn't in the repo yet. The new bit is the `population` field. Fixes #74.