### PR TITLE
Add whitelist status to /v2/commerce/prices

### DIFF
--- a/v2/commerce/prices.js
+++ b/v2/commerce/prices.js
@@ -1,16 +1,20 @@
 // Normal bulk-expanded endpoint that exposes aggregated price information
-// about items on the Trading Post.
+// about items on the Trading Post. Also shows whether or not they are whitelisted
+// to enable Play For Free accounts to buy or sell them.
 
 // GET /v2/commerce/prices
 [ 1, 2, 3, 4, ... ]
 
 // GET /v2/commerce/prices/5
 {
-    id   : 5,
+    id          : 5,
+    whitelisted : true,
+    
     buys : {
         quantity   : 20572,
         unit_price : 103
     },
+    
     sells: {
         quantity   : 12284,
         unit_price : 340


### PR DESCRIPTION
So you can check out which items a P4F account can buy/sell.
