### PR TITLE
Add /v2/wvw/matches

### DIFF
--- a/v2/wvw/matches.json
+++ b/v2/wvw/matches.json
@@ -1,0 +1,84 @@
+// Bulk-expanded endpoint that provides data for the
+// current WvW state.
+
+// GET /v2/wvw/matches
+[ "1-1", "1-2", "1-3" ]
+
+// GET /v2/wvw/matches/1-1
+// GET /v2/wvw/matches?id=1-1
+// GET /v2/wvw/matches?page=0&page_size=1
+
+{
+	"id"         : "1-1",
+	"start_time" : "2015-09-16T21:00:00Z",
+	"end_time"   : "2015-09-17T21:00:00Z",
+	"scores"     : {
+		"red"   : 44820,
+		"blue"  : 44820,
+		"green" : 44820
+	},
+	"ratings"    : {
+		"red"   : 1497.154175,
+		"blue"  : 1502.117432,
+		"green" : 1498.113525
+	},
+	"worlds"     : {
+		"red"   : 1001,
+		"blue"  : 1002,
+		"green" : 1003
+	},
+	"maps" : [
+		{
+			"id"         : 98,
+			"type"       : "RedHome",
+			"scores"     : {
+				"red"   : 11205,
+				"blue"  : 8715,
+				"green" : 8715
+			},
+			"bonuses" : [
+				{
+					"type"  : "Bloodlust",
+					"owner" : "Red"
+				}
+			],
+			"kills"  : {
+				"red"   : 0,
+				"blue"  : 1,
+				"green" : 0
+			},
+			"deaths" : {
+				"red"   : 0,
+				"blue"  : 0,
+				"green" : 50
+			},
+			"objectives" : [
+				{
+					"id"           : "98-102",
+					"owner"        : "Red",
+					"last_flipped" : "2015-09-18T18:12:29Z",
+					"claimed_by"   : "5AE7196D-F62F-E511-B0A0-0862664D7672",
+					"claimed_at"   : "2015-09-18T18:12:44Z"
+				},
+				{
+					"id"           : "98-103",
+					"owner"        : "Red",
+					"last_flipped" : "2015-09-18T18:12:29Z",
+					"claimed_by"   : null,
+					"claimed_at"   : null
+				},
+				...
+			]
+		},
+		...
+	]
+}
+
+// NOTES:
+//  * maps.N.id is a map_id that can be resolved against /v2/maps. This is 
+//    useful for determining which borderland is active.
+//  * maps.N.objectives.M.id references /v2/wvw/objectives.
+//  * maps.N.objectives.M.claimed_by is a guild GUID that can be resolved
+//    with /v1/guild_details.json.
+//  * Upgrades can be determined by checking last_flipped and claimed_at
+//    (since they'll be time-based at some point in the future).


### PR DESCRIPTION
This is what I've got for the new matches endpoint. This PR supplants #8.

I kind of want to make a `/v2/wvw/overview` or something that provides a `world_id -> match_id` mapping, but I'll save that for a separate PR. I'm also not entirely happy with putting the world MMR in this endpoint (feels like it belongs elsewhere maybe?) but eh.

Anyway, I *think* I've got most of the requested data in the new endpoint (I even got PPK data being piped through -- though Sentries aren't happening).