### PR TITLE
Add chat_link field to /v2/items

### DIFF
--- a/v2/items.js
+++ b/v2/items.js
@@ -23,6 +23,7 @@
     "flags": [ ],
     "restrictions": [ ],
     "id": 12138,
+    "chat_link": "[&AgFqLwAA]",
     "icon": "https://render.guildwars2.com/file/CA45CEE2BA3BA040E7C294965CA3756FC3F33FD1/63248.png"
 
 }


### PR DESCRIPTION
Would also like to add to `/v2/continents`, `/v2/skills`, `/v2/recipes`, and `/v2/traits` but those don't have example files yet.