### PR TITLE
Add /v2/achievements and /v2/achievements/daily.

### DIFF
--- a/v2/achievements/daily.js
+++ b/v2/achievements/daily.js
@@ -1,0 +1,34 @@
+// Provides today's daily achievements.
+
+// GET /v2/achievements/daily
+
+{
+	pve : [
+		{
+			id    : 34,
+			level : {
+				min : 1,
+				max : 80
+			}
+		},
+		{
+			id    : 35,
+			level : {
+				min : 11,
+				max : 79
+			}
+		}
+	],
+	pvp : [
+		...
+	],
+	wvw : [
+		...
+	]
+}
+
+// "id" corresponds to the achievement id and can be resolved
+// against /v2/achievements.
+
+// "level" is the min/max character level that this achievement
+// will be attainable for. The range is includive on both ends.

--- a/v2/achievements/daily.js
+++ b/v2/achievements/daily.js
@@ -2,6 +2,10 @@
 
 // GET /v2/achievements/daily
 
+[ "na", "eu" ]
+
+// GET /v2/achievements/daily/{na,eu}
+
 {
 	pve : [
 		{

--- a/v2/achievements/index.js
+++ b/v2/achievements/index.js
@@ -1,0 +1,47 @@
+// Normal bulk-expanded endpoint for fetching achievements.
+
+// GET /v2/achievements
+
+[ 1, 2, 3 ]
+
+// GET /v2/achievements/1
+
+{
+	"id"          : 1,
+	"icon"        : "https://render.guildwars2.com/...",
+	"name"        : "Some Achievement",
+	"description" : "A short text string about this achievement",
+	"requirement" : "What's displayed in-game about the requirements for this",
+	"type"        : "Default",
+	"flags"       : [
+		"Pvp"
+	]
+}
+
+// GET /v2/achievements?ids=1
+// GET /v2/achievements?page=0&page_size=1
+
+[
+	{
+
+	    "id"          : 1859,
+	    "icon"        : "https://render.guildwars2.com/...",
+	    "name"        : "Daily WvW Caravan Disruptor",
+	    "description" : "Cut off the enemy supply chain in the Mists.",
+	    "requirement" : "Destroy  enemy supply caravan in World versus World.",
+	    "type"        : "Default",
+	    "flags"       : [
+		"Pvp"
+	    ]
+
+	}
+]
+
+// "type" is either "Default" or "ItemSet".
+
+// "flags" can contain:
+//  * "Pvp" -- can only get progress in PvP or WvW
+//  * "CategoryDisplay" -- is a meta achievement
+//  * "MoveToTop" -- affects in-game UI collation
+//  * "IgnoreNearlyComplete" -- doesn't appear in the "nearly complete" UI
+


### PR DESCRIPTION
This is a first-pass -- for the initial release `/v2/achievements` will only be populated with the current daily achievements. I need to go through the entire list and make sure there's nothing that shouldn't be exposed before we can enable it for all the data.

We'll be extending the achievement endpoint a bit more when we release `/v2/account/achievements` so that for achievements that use a bitset internally for progress (e.g., Dungeon Master) you can reference what the individual bits mean (since `/v2/account/achievements` will just give you the completed bit indexes). That's kind of a longer-term change since it requires changes to the actual underlying content -- we have new support to display strings for the individual achievement steps in-game now.

Anyway, let me know if anything looks terribly off with the structure.