### PR TITLE
/v2/wvw/objectives: fix coordinates, add example.

### DIFF
--- a/v2/wvw/map-example.html
+++ b/v2/wvw/map-example.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src="https://code.jquery.com/jquery-1.9.1.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.5.1/leaflet.js"></script>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.5.1/leaflet.css"/>
+        <style>
+            .leaflet-container {
+                background: #000;
+            }
+
+            #map {
+                position: absolute;
+                top: 0;
+                right: 0;
+                bottom: 0;
+                left: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="map"></div>
+    
+        <script>
+            var files = {},
+                typeMap = {
+                    Camp   : "wvw_camp",
+                    Tower  : "wvw_tower",
+                    Keep   : "wvw_keep",
+                    Castle : "wvw_castle"
+                },
+                map;
+
+            function unproject(coord) {
+                return map.unproject(coord, map.getMaxZoom());
+            }
+
+            function onMapClick(e) {
+                console.log("You clicked the map at " + map.project(e.latlng));
+            }
+            
+            function onObjectives(objs) {
+                objs.forEach(function(obj) {
+                    if(!obj.coord) {
+                        return;
+                    }
+                    
+                    if(!obj.marker) {
+                        obj.marker = files[typeMap[obj.type]];
+                        if(!obj.marker) {
+                            return;
+                        }
+                    }
+                    
+                    var icon = L.icon({
+                        iconUrl : obj.marker,
+                        iconSize : [32, 32]
+                    });
+                    
+                    L.marker(unproject(obj.coord.slice(0, 2)), { icon : icon }).addTo(map);
+                });
+            }
+
+            $(function () {
+                "use strict";
+                
+                var apiBase  = "https://api.guildwars2.com",
+                    tileBase = "https://tiles.guildwars2.com",
+                    southWest, northEast;
+                
+                $.getJSON(apiBase + "/v2/files?ids=all", function(res) {
+                    res.forEach(function(file) {
+                        files[file.id] = file.icon;
+                    });
+                    $.getJSON(apiBase + "/v2/wvw/objectives?ids=all", onObjectives);
+                });
+
+
+                map = L.map("map", {
+                    minZoom: 0,
+                    maxZoom: 6,
+                    crs: L.CRS.Simple
+                }).setView([0, 0], 0);
+
+                southWest = unproject([0, 16384]);
+                northEast = unproject([16384, 0]);
+
+                map.setMaxBounds(new L.LatLngBounds(southWest, northEast));
+
+                L.tileLayer(tileBase + "/2/1/{z}/{x}/{y}.jpg", {
+                    minZoom: 0,
+                    maxZoom: 7,
+                    continuousWorld: true
+                }).addTo(map);
+
+                map.on("click", onMapClick);
+            });
+        </script>
+    </body>
+</html>

--- a/v2/wvw/objectives.js
+++ b/v2/wvw/objectives.js
@@ -15,6 +15,10 @@
 	coord     : [
 		6931.58,
 		14502.1
+	],
+	label_coord : [
+		6938.8,
+		14504.2
 	]
 }
 
@@ -31,6 +35,10 @@
 			7852.89,
 			9855.56
 		],
+		label_coord : [
+			7850.38,
+			9853.39
+		]
 		marker   : "https://render.guildwars2.com/..."
 	},
 	{
@@ -38,7 +46,6 @@
 		type      : "Keep",
 		map_type  : "RedHome",
 		map_id    : 94,
-		sector_id : 956,
 		name      : "Etheron Hills",
 		coord     : [
 			11212.6,
@@ -50,12 +57,7 @@
 		type      : "Tower",
 		map_type  : "Center",
 		map_id    : 38,
-		sector_id : 485,
-		name      : "Aldon's Ledge",
-		coord     : [
-			9417.39,
-			14790.7
-		]
+		name      : "Aldon's Ledge"
 	}
 ]
 
@@ -80,8 +82,12 @@
 //   * ObsidianSanctum
 //   * EdgeOfTheMists
 //
-// coord and sector_id may not be present on all objects. When one is
-// missing the other will be too -- the coord is the sector centroid.
+// label_coord and sector_id may not be present on all objects. When one is
+// missing the other will be too -- the label_coord is the sector centroid
+// and is where the sector name label is displayed.
+//
+// coord may also be missing on some objects. coord contains the location
+// of the capture ring, which is where the marker is displayed in-game.
 //
 // marker may not be present on all objects.
 //


### PR DESCRIPTION
The coordinates we're currently returning are the label coordinates. These are being moved to the `label_coord` field and the *correct* coordinates for the objective marker are going to the `coord` field. Also included is a quick and dirty sample with leaflet.js that puts the objectives on a map (from the tile service).