### PR TITLE
Support finding matches by world ID

### DIFF
--- a/v2/wvw/matches.json
+++ b/v2/wvw/matches.json
@@ -7,6 +7,7 @@
 // GET /v2/wvw/matches/1-1
 // GET /v2/wvw/matches?id=1-1
 // GET /v2/wvw/matches?page=0&page_size=1
+// GET /v2/wvw/matches?world_id=1001
 
 {
 	"id"         : "1-1",


### PR DESCRIPTION
Currently applications looking to provide WvW match data for a particular world need to either:
 A) Use /v1/wvw/matches.json to map world IDs to match IDs, or
 B) use /v2/wvw/matches to get all current matches and find the one with the right world ID

While providing a new endpoint to map world IDs to match IDs is one solution (and would be great for some use cases), providing the ability to directly query /v2/wvw/matches for the match containing a particular world ID would eliminate an extra API call when applications just want to display a given world's current match data.