### PR TITLE
Add endpoints to retrieve mini data and unlocks.

### DIFF
--- a/v2/account/minis.js
+++ b/v2/account/minis.js
@@ -1,0 +1,8 @@
+// Returns a list of mini ids that the account has unlocked; these
+// can be resolved against /v2/minis.
+
+// GET /v2/account/minis
+// Authorization: Bearer api-key
+// Requires "account" and "unlocks" scopes.
+
+[ 1, 2, 3 ]

--- a/v2/minis.js
+++ b/v2/minis.js
@@ -1,0 +1,28 @@
+// Normal bulk-expanded endpoint
+// GET /v2/minis
+
+[ 1, 2, 3, ... ]
+
+// GET /v2/minis/1
+// GET /v2/minis?id=1
+
+{
+	"id" : 1,
+	"name" : "Mini Orrian Wraith",
+	"icon" : "https://render.guildwars2.com/...",
+	"order" : 154,
+	"item_id" : 20166
+}
+
+// GET /v2/minis?ids=1,2
+
+[ /* mini 1 */, /* mini 2 */ ]
+
+// GET /v2/minis?page=0&page_size=3
+
+[ /* mini 1 */, /* mini 2 */, /* mini 3 */ ]
+
+// NOTES:
+// * "order" is the sort order that's used for displaying the minis in-game.
+// * "item_id" is the item which unlocks the mini and can be resolved against
+//   /v2/items.


### PR DESCRIPTION
This one's pretty straightforward. There's currently not much data in `/v2/minis`, but I don't want to just jam it into `/v2/items.details` (because there might be more later, and mini ids are probably referenced from other places (e.g., achievements)).

Would like to get this deployed later this week or early next week, so if you see any issues let me know soonish <3