### PR TITLE
Remove the na/eu split from /v2/achievements/daily.

### DIFF
--- a/v2/achievements/daily.js
+++ b/v2/achievements/daily.js
@@ -2,10 +2,6 @@
 
 // GET /v2/achievements/daily
 
-[ "na", "eu" ]
-
-// GET /v2/achievements/daily/{na,eu}
-
 {
 	pve : [
 		{


### PR DESCRIPTION
I'm not sure what I was thinking. na/eu have the same daily achievements
and the same reset times (00:00 UTC).

This amends #96 (already merged); there's additional discussion in #120.