### PR TITLE
Add /v2/guild/permissions.

### DIFF
--- a/v2/guild/permissions.js
+++ b/v2/guild/permissions.js
@@ -1,0 +1,29 @@
+// Provides details about guild permission id strings.
+// Bulk-expanded endpoint with string keys:
+
+// GET /v2/guild/permissions
+[
+    "Admin",
+    "TeamAdmin",
+    ...
+]
+
+// GET /v2/guild/permissions/TeamAdmin
+// GET /v2/guild/permissions?id=TeamAdmin
+
+{
+    "id": "TeamAdmin",
+    "name": "Team Administrator",
+    "description": "Create or delete teams and add or remove team members."
+}
+
+// GET /v2/guild/permissions?page=0&page_size=1
+// GET /v2/guild/permissions?ids=TeamAdmin
+
+[
+	{
+	    "id": "TeamAdmin",
+	    "name": "Team Administrator",
+	    "description": "Create or delete teams and add or remove team members."
+	}
+]


### PR DESCRIPTION
This endpoint maps from the permission enum values (e.g., `TeamAdmin`) to the localized strings that are displayed in-game. The enum values will be referenced from the `/v2/guild/:id/ranks` endpoint once I've got that written up to describe which ranks have which permissions.