### PR TITLE
Add daily/monthly AP fields to /v2/account.

### DIFF
--- a/v2/account/account.js
+++ b/v2/account/account.js
@@ -11,7 +11,11 @@
 		"8B211747-3B86-E411-B57A-00224D566B58"
 	],
 	"access"  : "HeartOfThorns",
-	"created" : "2015-06-05T19:45:00Z"
+	"created" : "2015-06-05T19:45:00Z",
+
+	// Included only if "progression" scope is set.
+	"daily_ap"   : 40,
+	"monthly_ap" : 60
 }
 
 // "access" is one of:


### PR DESCRIPTION
Requires the `progression` permission (to match `/v2/account/achievements). I'm not totally happy with the field names; suggestions welcome!

refs #138