### PR TITLE
Add /v2/guild/:id/treasury which dumps treasury contents.

### DIFF
--- a/v2/guild/treasury.js
+++ b/v2/guild/treasury.js
@@ -1,0 +1,18 @@
+// Authenticated endpoint that outputs guild treasury.
+// **only available with keys from guild leaders for now**
+// Requires scope: "guilds"
+
+// GET /v2/guilds/:id/treasury?access_token=:token
+
+[
+	{
+		id    : 12138,
+		count : 200
+	},
+	{
+		id    : 19684,
+		count : 3493
+	}
+]
+
+// "id" is an item id and can be resolved against /v2/items.

--- a/v2/guild/treasury.js
+++ b/v2/guild/treasury.js
@@ -6,13 +6,33 @@
 
 [
 	{
-		id    : 12138,
-		count : 200
+		id        : 12138,
+		count     : 200,
+		needed_by : [
+			{
+				upgrade_id : 42,
+				count      : 1000
+			}
+		]
 	},
 	{
-		id    : 19684,
-		count : 3493
+		id        : 19684,
+		count     : 3493,
+		needed_by : [
+			{
+				upgrade_id : 42,
+				count      : 3000
+			},
+			{
+				upgrade_id : 43,
+				count      : 3000
+			}
+		]
 	}
 ]
 
 // "id" is an item id and can be resolved against /v2/items.
+
+// "needed_by" is the list of in-progress upgrades that require
+// this item. The maximum count of an item can be computed by
+// summing the "needed_by[n].count" values.


### PR DESCRIPTION
Basically just dumps out an array of itemstacks that represents the current treasury state. For tracking who donated what (what when), I want to also expose the guild's event log (that's visible in the in-game history tab of the guild panel), but that's a separate pull request.

refs #121

Thoughts on the output format?