### PR TITLE
Add /v2/guild/:id/stash.

### DIFF
--- a/v2/guild/stash.js
+++ b/v2/guild/stash.js
@@ -1,0 +1,25 @@
+// Authenticated endpoint that outputs guild stash contents.
+// **only available with keys from guild leaders for now**
+// Requires scope: "guilds"
+
+[
+	{
+		"upgrade_id" : 58,
+		"size" : 100,
+		"coins" : 100039,
+		"inventory" : [
+			null,
+			null,
+			{
+				"id" : 12138,
+				"count" : 250
+			},
+			null,
+			null,
+			null,
+			// ... 100 entries in total.
+		]
+	},
+	// ...
+]
+


### PR DESCRIPTION
Pretty straightforward -- is basically the same as `/v2/characters.inventory` except that it's got an `upgrade_id` and `coins`.

Thought I had already pushed this, but alas.