### PR TITLE
Add in guild_ingredients and output_upgrade_id.

### DIFF
--- a/v2/recipes.js
+++ b/v2/recipes.js
@@ -22,8 +22,8 @@
 	"chat_link": "[&CQEAAAA=]"
 }
 
-// GET /v2/recipes?ids=1
-// GET /v2/recipes?page=0&page_size=1
+// GET /v2/recipes?ids=1,11588
+// GET /v2/recipes?page=0&page_size=2
 
 [
 	{
@@ -40,5 +40,31 @@
 		}],
 		"id": 1,
 		"chat_link": "[&CQEAAAA=]"
+	},
+	{
+		"type": "GuildDecoration",
+		"output_item_id": 75627,
+		"output_item_count": 1,
+		"min_rating": 25,
+		"time_to_craft_ms": 1000,
+		"disciplines": ["Scribe"],
+		"flags": ["AutoLearned"],
+		"ingredients": [{
+			"item_id": 71918,
+			"count": 1
+		}, {
+			"item_id": 76646,
+			"count": 1
+		}, {
+			"item_id": 19710,
+			"count": 5
+		}],
+		"guild_ingredients": [{
+			"upgrade_id": 418,
+			"count": 1
+		}],
+		"output_upgrade_id": 618,
+		"id": 11588,
+		"chat_link": "[&CUQtAAA=]"
 	}
 ]


### PR DESCRIPTION
These refer to the scribe recipe components that are pulled from/put into
the guild inventory (because they're not items -- they're actually guild
upgrades, e.g., decorations or schematics).

refs #174 