### PR TITLE
Add special achievements to /v2/achievements/daily.

### DIFF
--- a/v2/achievements/daily.js
+++ b/v2/achievements/daily.js
@@ -24,6 +24,8 @@
 	],
 	wvw : [
 		...
+	],
+	special : [
 	]
 }
 
@@ -32,3 +34,6 @@
 
 // "level" is the min/max character level that this achievement
 // will be attainable for. The range is includive on both ends.
+
+// "special" is for temporary content, mostly festival dailies
+// and the like. If there's no temporary content, [] is returned.


### PR DESCRIPTION
refs #162 

It's kind of weird that they're not in the pve section, but the achievements are being sorted based on flags in content. So yeah.