### PR TITLE
Add tier_text to /v2/achievements.

### DIFF
--- a/v2/achievements/index.js
+++ b/v2/achievements/index.js
@@ -93,11 +93,43 @@
 	}
 ]
 
+// GET /v2/achievements?ids=98,121,129,1681
+
+[
+	{
+		"id"        : 98,
+		"name"      : "To Know the Unknown",
+		"tiers"     : [{"count":1,"points":10}],
+		"tier_text" : "Story Achievement"
+	},
+	{
+		"id"        : 121,
+		"name"      : "Dungeons Discovered",
+		"tiers"     : [{"count":1,"points":5},...,{"count":8,"points":5}],
+		"tier_text" : "%str1% Dungeon Story[pl:\"Stories\"] Complete"
+	},
+	{
+		"id"        : 129,
+		"name"      : "Agent of Entropy",
+		"tiers"     : [{"count":200,"points":2}],
+		"tier_text" : "%str1%/%str2% Items Salvaged"
+	},
+	{
+		"id"        : 1681,
+		"name"      : "Birthday—Year 1",
+		"tiers"     : [{"count":1,"points":1}],
+		"tier_text" : ""
+	}
+]
+
 // "type" is either "Default" or "ItemSet".
 
 // "tiers.n.count" is the number of <things> needed to reach this
 // tier. "tiers.n.points" is the non-cumulative AP awarded for reaching
 // the tier.
+
+// "tier_text" is the format text for each tier. 
+// "%str1%" is current count and "%str2%" is final count.
 
 // "point_cap" is the maximum number of AP that may be awarded by
 // a repeatable achievement.


### PR DESCRIPTION
This change adds `tier_text` to allow displaying of tier text. The tier text can be seen in the tooltips of achievement watchlist HUD (on the right side of the screen, "Tier: X/Z Foobar\nTotal: Y/Z Foobar") and the achievement categories view (by selecting a category, and then viewing the tooltip for an achievement).

Some achievements do not have any text for tiers (e.g. [Birthday—Year 1](https://api.guildwars2.com/v2/achievements/1681)). This can be represented as a blank string, or by making this field optional.

For one-argument strings (i.e. `"%str1% Dungeon Story[pl:\"Stories\"] Complete"`), singular form is followed by plural form (e.g. `Item[s]` or `Match[pl:"Matches"]`). This is a bonus to find grammatical errors in the game data — namely single argument strings where a tier's count is 1 but the text is plural, such as "1 Ranked Matches Won as a Mesmer" (typo is only as an example; game uses correct singular form for this achievement)