### PR TITLE
Break /v2/commerce/listings to not return the entire set.

### DIFF
--- a/v2/commerce/listings.js
+++ b/v2/commerce/listings.js
@@ -1,28 +1,56 @@
-// Normal bulk-expanded endpoint that exposes detailed listing information
-// about items on the Trading Post.
+// Endpoint that exposes detailed listing information
+// about item listings on the Trading Post.
 
 // GET /v2/commerce/listings
 [ 1, 2, 3, 4, ... ]
 
 // GET /v2/commerce/listings/5
+// GET /v2/commerce/listings/5?page=0&page_size=200
 {
-    id   : 5,
-    buys : [ {
-        listings   : 2
-        unit_price : 103,
-        quantity   : 10
-    }, {
-        listings   : 5,
-        unit_price : 102,
-        quantity   : 6
-    } ],
-    sells: [ {
-        listings   : 1,
-        unit_price : 340,
-        quantity   : 229
-    }, {
-        listings   : 2,
-        unit_price : 341,
-        quantity   : 55
-    } ]
+    id : 5,
+
+    buys_total  : 2,
+    sells_total : 2,
+
+    buys_listings_total  : 7,
+    buys_quantity_total  : 16,
+    sells_listings_total : 3,
+    sells_quantity_total : 284,
+
+    buys  : [
+        {
+            listings   : 2
+            unit_price : 103,
+            quantity   : 10
+        },
+        {
+            listings   : 5,
+            unit_price : 102,
+            quantity   : 6
+        }
+    ],
+    sells: [
+        {
+            listings   : 1,
+            unit_price : 340,
+            quantity   : 229
+        },
+        {
+            listings   : 2,
+            unit_price : 341,
+            quantity   : 55
+        }
+    ]
 }
+
+// NOTES:
+//  Pagination works a bit differently -- both buys/sells are
+//  paginated simultaneously (moving outwards from the spread
+//  as pages go up).
+//
+//  Normal pagination details are returned in the response
+//  headers, though their meanings are a bit distorted:
+//    * X-Page-Total   -- total number of pages
+//    * X-Result-Total -- total  number of results
+//    * X-Page-Count   -- (buys.length + sells.length) in response
+//    * X-Result-Total -- (buys.length + sells.length) in total


### PR DESCRIPTION
Currently /v2/commerce/listings returns potentially huge responses which
are only useful for a small subset of applications -- but a small subset
of the data returned is valuable more widely. This incongruity is causing
some undue stress; the goal of this breaking change is to limit the
response size for the common case while still providing access to the full
dataset for applications which need it.

By applying pagination.

In the current revision, aggregates are provided in all responses -- not
sure how much I like this (or the aggregate field names). This should make it
so that applications wishing to display the total number of listings/quantity
don't have to fetch the whole dataset.

Anyway, this is a pretty big breaking change (in that applications wanting the
entire result set will need to be updated). I don't have a timeline yet but spread
the word.