### PR TITLE
/v2/pvp/seasons and additions to /v2/pvp/games.

### DIFF
--- a/v2/pvp/games.js
+++ b/v2/pvp/games.js
@@ -29,7 +29,9 @@
 	"scores": {
 		"red": 344,
 		"blue": 500
-	}
+	},
+	"rating_type" : "Ranked",
+	"season" : "49CCE661-9DCC-473B-B106-666FE9942721"
 }
 
 // GET /v2/pvp/games?ids=all&access_token=foo
@@ -46,7 +48,24 @@
 		"scores": {
 			"red": 344,
 			"blue": 500
-		}
+		},
+		"rating_type" : "Ranked"
 	},
 	...
 ]
+
+// NOTES:
+//  "rating_type" is one of the following values:
+//
+//   * "None" -- custom arenas and such
+//   * "Unranked"
+//   * "Ranked"
+//   * "SoloArenaRated" -- deprecated
+//   * "TeamArenaRated" -- deprecated
+//
+//  you shouldn't be able to get the deprecated enumeration values unless
+//  you've got an API key for an account that hasn't PvP'd since those
+//  queues were available.
+//
+//  "season" may be omitted -- believe it's only present for games with
+//  rating_type="Ranked". Can be cross-referenced against /v2/pvp/seasons.

--- a/v2/pvp/seasons.js
+++ b/v2/pvp/seasons.js
@@ -1,0 +1,56 @@
+// Bulk-expanded endpoint that exposes PvP season data. Supports
+// localization via the ?lang parameter.
+
+// GET /v2/pvp/seasons
+
+[ "44B85826-B5ED-4890-8C77-82DDF9F2CF2B" ]
+
+// GET /v2/pvp/seasons?id=44B85826-B5ED-4890-8C77-82DDF9F2CF2B
+// GET /v2/pvp/seasons/44B85826-B5ED-4890-8C77-82DDF9F2CF2B
+
+{
+    "id": "44B85826-B5ED-4890-8C77-82DDF9F2CF2B",
+    "name": "PvP League Season One",
+    "divisions": [
+    {
+        "name": "Division 1: Amber",
+        "flags": [],
+        "large_icon": "https://render...",
+        "small_icon": "https://render...",
+        "pip_icon": "https://render...",
+        "tiers": [
+        {
+            "points": 5
+        },
+        {
+            "points": 5
+        },
+        {
+            "points": 5
+        }]
+    },
+    // ...
+    {
+        "name": "Division 6: Legendary",
+        "flags": ["CanLosePoints", "CanLoseTiers", "Repeatable"],
+        "large_icon": "https://render...",
+        "small_icon": "https://render...",
+        "pip_icon": "https://render...",
+        "tiers": [
+        {
+            "points": 5
+        },
+        {
+            "points": 5
+        },
+        {
+            "points": 5
+        },
+        {
+            "points": 5
+        },
+        {
+            "points": 5
+        }]
+    }]
+}


### PR DESCRIPTION
Basically just some endpoints that dump out basic information about various PvP seasons, and in which season a game belongs. I'll make another PR later which contains authenticated season standing data (e.g., maybe by adding it to `/v2/pvp/stats`) but for now this just associates games with seasons, where appropriate (and also exposes which queue the game was played in).