### PR TITLE
Add /v2/account/inventory, which dumps shared inventory slots.

### DIFF
--- a/v2/account/inventory.js
+++ b/v2/account/inventory.js
@@ -1,0 +1,15 @@
+// Returns a list of item stacks representing the account's shared
+// inventory slots.
+
+// GET /v2/account/inventory
+// Authorization: Bearer api-key
+// Requires "account" and "inventories" scopes.
+
+[
+	null,
+	{
+		id : 12138,
+		count : 250
+	},
+	null
+]


### PR DESCRIPTION
refs #180 

Meant to have the backend support in for the latest release, but I totally forgot that it's stored internally as a sparse array and I needed to include the total number of slots available. So it won't be ready until the next release, unfortunately :(