### PR TITLE
Add "order" field to /v2/materials.

### DIFF
--- a/v2/materials.js
+++ b/v2/materials.js
@@ -8,6 +8,7 @@
 {
 	id: 5,
 	name: "Cooking Materials",
+	order: 16,
 	items: [
 		12134,
 		12238,
@@ -22,6 +23,7 @@
 [
 	{
 		id: 5,
+		order: 16
 		name: "Zutaten zum Kochen",
 		items: [
 			12134,
@@ -32,3 +34,7 @@
 	},
 	...
 ]
+
+// NOTES:
+//  * "order" is used for sorting in the UI; it's not necessarily
+//    monotonically incrementing.


### PR DESCRIPTION
Not sure how I overlooked this, but it would be helpful if applications didn't have to hardcode the in-game sort order.