### PR TITLE
Add guild details

### DIFF
--- a/v2/guild/details.js
+++ b/v2/guild/details.js
@@ -22,6 +22,8 @@
      "background": 27,
      "foreground": 114,
      "flags": [],
+     "member_count": 20,
+     "member_capacity": 50,
      "background_color": 11,
      "foreground_primary_color": 584,
      "foreground_secondary_color": 64

--- a/v2/guild/details.js
+++ b/v2/guild/details.js
@@ -1,0 +1,32 @@
+// Unauthenticated endpoint which outputs public details of a guild.
+
+// GET /v2/guilds
+// This will output all currently registered guilds ids to the user.
+// Example:
+[
+    "F05AA71F-37CD-4857-B632-517909765E4F",
+    "20034A78-E176-44B5-A5FE-07F80C1E7A05",
+    "3E579C5D-055F-48A6-9E09-F921588F83B1",
+    "61443D40-BACD-4D09-83A6-3C761A7BAAE3",
+    ...
+]
+
+// GET v2/guilds/:id or v2/guilds?ids=:id
+// This will output the public details of a guild a given od
+// Example:
+{
+   "id": "75FD83CF-0C45-4834-BC4C-097F93A487AF",
+   "name": "Veterans Of Lions Arch",
+   "tag": "LA",
+   "emblem": {
+     "background": 27,
+     "foreground": 114,
+     "flags": [],
+     "background_color": 11,
+     "foreground_primary_color": 584,
+     "foreground_secondary_color": 64
+   }
+ }
+
+ // GET v2/guilds?ids=:ids
+ // Same as above only that an array of guild details is returned

--- a/v2/guild/details.js
+++ b/v2/guild/details.js
@@ -22,6 +22,7 @@
      "background": 27,
      "foreground": 114,
      "flags": [],
+     "recruting_text": "Lorem Ipsum"
      "member_count": 20,
      "member_capacity": 50,
      "background_color": 11,

--- a/v2/guild/details.js
+++ b/v2/guild/details.js
@@ -22,7 +22,6 @@
      "background": 27,
      "foreground": 114,
      "flags": [],
-     "recruting_text": "Lorem Ipsum"
      "member_count": 20,
      "member_capacity": 50,
      "background_color": 11,

--- a/v2/guild/details.js
+++ b/v2/guild/details.js
@@ -18,12 +18,12 @@
    "id": "75FD83CF-0C45-4834-BC4C-097F93A487AF",
    "name": "Veterans Of Lions Arch",
    "tag": "LA",
+   "member_count": 20,
+   "member_capacity": 50,
    "emblem": {
      "background": 27,
      "foreground": 114,
      "flags": [],
-     "member_count": 20,
-     "member_capacity": 50,
      "background_color": 11,
      "foreground_primary_color": 584,
      "foreground_secondary_color": 64

--- a/v2/schemas/guilds/guilds.json
+++ b/v2/schemas/guilds/guilds.json
@@ -16,6 +16,8 @@
                 "tag": {
                     "type": "string"
                 },
+                "member_count": "integer",
+                "member_capacity": "integer",
                 "emblem": {
                     "$ref": "#/definitions/guildEmblem"
                 }

--- a/v2/schemas/guilds/guilds.json
+++ b/v2/schemas/guilds/guilds.json
@@ -1,0 +1,89 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://api.guildwars2.com/v2/guilds",
+    "title": "Guild Schema (v2)",
+    "description": "This schema validates the unauthenticated response returned by the v2/guilds and all sub nodes.",
+    "definitions": {
+        "guildDetails": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                },
+                "emblem": {
+                    "$ref": "#/definitions/guildEmblem"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "id",
+                "name",
+                "tag",
+                "emblem"
+            ]
+        },
+        "guildEmblem": {
+            "type": "object",
+            "properties": {
+                "background": {
+                    "type": "integer"
+                },
+                "foreground": {
+                    "type": "integer"
+                },
+                "flags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "FlipBackgroundHorizontal",
+                            "FlipBackgroundVertical",
+                            "FlipForegroundHorizontal",
+                            "FlipForegroundVertical"
+                        ]
+                    },
+                    "additionalProperties": false
+                },
+                "background_color": {
+                    "type": "integer"
+                },
+                "foreground_primary_color": {
+                    "type": "integer"
+                },
+                "foreground_secondary_color": {
+                    "type": "integer"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "background",
+                "foreground",
+                "flags",
+                "background_color",
+                "foreground_primary_color",
+                "foreground_secondary_color"
+            ]
+        }
+    },
+    "anyOf": [{
+        "type": "array",
+        "items": {
+            "type": "string"
+        }
+    },
+    {
+        "type": "array",
+        "items": {
+            "$ref": "#/definitions/guildDetails"
+        }
+    },
+    {
+        "$ref": "#/definitions/guildDetails"
+    }]
+}

--- a/v2/schemas/guilds/guilds.json
+++ b/v2/schemas/guilds/guilds.json
@@ -13,6 +13,10 @@
                 "name": {
                     "type": "string"
                 },
+                "recruting_text": {
+                    "type": "string",
+                    "maxLength": 500
+                },
                 "tag": {
                     "type": "string"
                 },

--- a/v2/schemas/guilds/guilds.json
+++ b/v2/schemas/guilds/guilds.json
@@ -13,10 +13,6 @@
                 "name": {
                     "type": "string"
                 },
-                "recruting_text": {
-                    "type": "string",
-                    "maxLength": 500
-                },
                 "tag": {
                     "type": "string"
                 },


### PR DESCRIPTION
Currently guild details is the only v1 endpoint left. This PR tries to move the endpoint to v2 of the api.

Problems this PR tries to solve:
1. Guild details were only available when the user knew the id beforehand
2. Exposing too much sensitive information is not preferable
3. Guilds should be able to advertise themselves

Solutions taken by the PR:
1. By calling v2/guilds the user gets a list of all current guilds in the game. Without any suitable endpoint or authentication scope this information will be useless and not harmful
2. By calling v2/guilds/{id} or v2/guilds?ids={ids} the user will get a list of _public_ guild information. This information centres around information a guild would willingly give to the piblic for the sake of advertising. This means we expose Name, Tag, Current and Max Member Count as well as the emblem.

Possible Solutions not taken by this PR:
1. Add a recruiting text for the outside world. This was intended, but not possible since there is no representation of this in-game.
2. Add a field of all members who can invite new recruits. Possible security implications by exposing member names via a public API spoke against this (maybe add this with authentication).
