### PR TITLE
Add Titles to /v2/achievements.

### DIFF
--- a/v2/achievements/index.js
+++ b/v2/achievements/index.js
@@ -35,6 +35,10 @@
 		{
 			"type"   : "Mastery",
 			"region" : "Tyria"
+		},
+		{
+			"type"   : "Title",
+			"name"   : "FancyTitle"
 		}
 	],
 	"bits"        : [


### PR DESCRIPTION
Would be nice to see Titles rewarded for achievements exposed in the `rewards` section.