### PR TITLE
Add /v2/itemstats; add references to it from itemstacks.

### DIFF
--- a/v2/account/bank.js
+++ b/v2/account/bank.js
@@ -27,6 +27,16 @@
 		upgrades: [
 			24661
 		],
+		// stats only present for choosy-stat items.
+		stats: {
+			// id refers to /v2/itemstacks.
+			id: 161,
+			attributes: {
+				Power: 251,
+				Precision: 179,
+				CritDamage: 179
+			}
+		},
 		binding: "Character",
 		bound_to: "Quagga Backpaker"
 	},

--- a/v2/characters/characters.js
+++ b/v2/characters/characters.js
@@ -95,7 +95,17 @@
 			id: 6470,
 			slot: "Boots"
 			binding: "Character",
-			bound_to: "Hello"
+			bound_to: "Hello",
+			// stats only present for choosy-stat items.
+			stats: {
+				// id refers to /v2/itemstacks.
+				id: 161,
+				attributes: {
+					Power: 251,
+					Precision: 179,
+					CritDamage: 179
+				}
+			}
 		},
 		{
 			id: 6549,

--- a/v2/itemstats.js
+++ b/v2/itemstats.js
@@ -1,0 +1,43 @@
+// Bulk-expanded endpoint that provides access to 
+// "item stat" objects -- these are basically the
+// prefixes that define the attribute ratios for
+// items.
+
+// GET /v2/itemstats
+
+[ 161, 162, /* ... */ ]
+
+// GET /v2/itemstats/161
+// GET /v2/itemstats?id=161
+
+{
+	"name" : "Berserker's",
+	"attributes" : {
+		"Power"      : 0.35,
+		"Precision"  : 0.25,
+		"CritDamage" : 0.25
+	}
+}
+
+// GET /v2/itemstats?page=0&page_size=1
+// GET /v2/itemstats?ids=161
+
+[
+	{
+		"name" : "Berserker's",
+		"attributes" : {
+			"Power"      : 0.35,
+			"Precision"  : 0.25,
+			"CritDamage" : 0.25
+		}
+	}
+]
+
+// NOTES:
+//  * "attributes" contains the multipliers; these are combined
+//    with the item level, rarity, and some additional look-up
+//    tables to get the final stat amounts. Since we don't currently
+//    provide the other bits, they're only useful for relative
+//    comparisons (e.g., Berserker's vs. Celestial). The absolute
+//    attribute values are provided in itemstack objects (e.g.
+//    when fetched from a character's inventory or bank).


### PR DESCRIPTION
For choosy-stat items (e.g., legendaries) this adds additional data in the itemstacks returned from `/v2/account/bank` and `/v2/characters` to indicate which stat combos are selected. The actual attributes granted by a combo vary by item, so they're put directly on the itemstack. The localized combo name can be pulled from `/v2/itemstats`.

Might make more sense to call it `/v2/statcombos`, not sure.

refs #177 