### PR TITLE
Add .weapons field to /v2/professions.

### DIFF
--- a/v2/professions.js
+++ b/v2/professions.js
@@ -88,7 +88,7 @@
 				// Each thief dual-wield indicates which
 				// offhand it requires.
 				{
-					"id"      : 14003",
+					"id"      : 14003,
 					"slot"    : "Weapon_3",
 					"offhand" : "Dagger"
 				},

--- a/v2/professions.js
+++ b/v2/professions.js
@@ -75,7 +75,40 @@
 				// ...
 			]
 		}
-	]
+	],
+	"weapons" : {
+		"Dagger" : {
+			"skills" : [
+				// Most skills look like this.
+				{
+					"id"   : 13004,
+					"slot" : "Weapon_1"
+				},
+
+				// Each thief dual-wield indicates which
+				// offhand it requires.
+				{
+					"id"      : 14003",
+					"slot"    : "Weapon_3",
+					"offhand" : "Dagger"
+				},
+
+				// Elementalist skills indicate their
+				// attunement.
+				{
+					"id"         : 1200,
+					"slot"       : "Weapon_1",
+					"attunement" : "Fire"
+				}
+			]
+		},
+		"Staff" : {
+			// Weapons that require a specialization to
+			// use have an extra "specialization" field.
+			"specialization" : 12,
+			"skills" : [ /* ... */ ]
+		}
+	}
 }
 
 // Can also fetch multiple professions via bulk-expanded options, e.g.


### PR DESCRIPTION
Have an implementation as-described, but it'll take a couple weeks for the backend changes to go through the pipeline. Let me know if the output format could be improved (or if there's class mechanics I missed -- will likely add DS/CA skills somewhere else since they're transforms, not weapons) (also for other profession mechanics (shatters, virtues)).

refs #263 