### PR TITLE
Add /v2/account/contacts.

### DIFF
--- a/v2/account/contacts.js
+++ b/v2/account/contacts.js
@@ -1,0 +1,43 @@
+// Authenticated endpoint (requires "contacts" permission) that
+// dumps out the account's contacts.
+
+// GET /v2/account/contacts
+
+[ "friends", "followers", "blocked" ]
+
+// GET /v2/account/contacts/friends
+// Authorization: Bearer <contacts API key>
+
+[
+	{
+		"id"       : "guid",
+		"name"     : "Lawton.7615",
+		"nickname" : "My Other Account"
+	}
+]
+
+// GET /v2/account/contacts/blocked
+// Authorization: Bearer <contacts API key>
+
+[
+	{
+		"id"   : "guid",
+		"name" : "Lawton II.1111"
+	}
+]
+
+// GET /v2/account/contacts/followers
+// Authorization: Bearer <contacts API key>
+
+[
+	{
+		"id"   : "guid",
+		"name" : "Lawton III.2948"
+	}
+]
+
+// NOTES:
+//  * "id" corresponds to the account id, as obtainable from
+//    /v2/account.
+//  * "nickname" is omitted if you've not set a nickname for
+//    the contact.


### PR DESCRIPTION
I'm not entirely convinced I like the "split into different endpoints" approach. Might make more sense to have them separated? The main reason I wanted them split is because I have like 500+ goldsellers blocked and don't really care about that overhead when I'm just pulling down my friends list (e.g., to rate my account against theirs on various sites).

This doesn't expose presence data (e.g., the offline/online/map location bits). Will open a separate issue for that.

Also should note that this adds a new permission, "contacts", which provides access to this endpoint. Need to figure out what other things that might grant access to (so we avoid permission overload).

refs #270 
