### PR TITLE
Add /v2/titles, /v2/account/titles and title rewards to /v2/achievements.

### DIFF
--- a/v2/account/titles.js
+++ b/v2/account/titles.js
@@ -1,0 +1,10 @@
+// GET /v2/account/titles
+// Authorization: Bearer API-key
+// Requires "account" and "unlocks" scopes.
+[
+	1,
+	2,
+	3
+]
+
+// Returned ids are titles and can be resolved via /v2/titles.

--- a/v2/achievements/index.js
+++ b/v2/achievements/index.js
@@ -38,7 +38,7 @@
 		},
 		{
 			"type"   : "Title",
-			"name"   : "FancyTitle"
+			"id"     : 6 // references /v2/titles.
 		}
 	],
 	"bits"        : [

--- a/v2/characters/characters.js
+++ b/v2/characters/characters.js
@@ -19,7 +19,7 @@
 	created: "2015-06-05T19:45:00Z",
 	age: 91, // in seconds.
 	deaths: 0,
-	title: 17, // references /v2/titles; null if no title set
+	title: 17, // references /v2/titles
 	crafting: [
 		{
 			discipline : "Leatherworker",
@@ -53,7 +53,6 @@
 		created: "2015-06-05T19:45:00Z",
 		age: 91,
 		deaths: 0,
-		title: null,
 		crafting: [
 			{
 				discipline : "Cook",
@@ -87,7 +86,6 @@
 	created: "2015-06-05T19:45:00Z",
 	age: 91,
 	deaths: 0,
-	title: null,
 	equipment: [
 		{
 			id: 6472,
@@ -174,7 +172,6 @@
 	created: "2015-06-05T19:45:00Z",
 	age: 91,
 	deaths: 0,
-	title: null,
 	equipment: [
 		{
 			id: 6472,

--- a/v2/characters/characters.js
+++ b/v2/characters/characters.js
@@ -19,6 +19,7 @@
 	created: "2015-06-05T19:45:00Z",
 	age: 91, // in seconds.
 	deaths: 0,
+	title: 17, // references /v2/titles; null if no title set
 	crafting: [
 		{
 			discipline : "Leatherworker",
@@ -52,6 +53,7 @@
 		created: "2015-06-05T19:45:00Z",
 		age: 91,
 		deaths: 0,
+		title: null,
 		crafting: [
 			{
 				discipline : "Cook",
@@ -84,7 +86,8 @@
 	guild: "1F5F70AA-1DB6-E411-A2C4-00224D566B58",
 	created: "2015-06-05T19:45:00Z",
 	age: 91,
-	deaths: 0
+	deaths: 0,
+	title: null,
 	equipment: [
 		{
 			id: 6472,
@@ -170,7 +173,8 @@
 	guild: "1F5F70AA-1DB6-E411-A2C4-00224D566B58",
 	created: "2015-06-05T19:45:00Z",
 	age: 91,
-	deaths: 0
+	deaths: 0,
+	title: null,
 	equipment: [
 		{
 			id: 6472,

--- a/v2/titles.js
+++ b/v2/titles.js
@@ -8,7 +8,8 @@
 
 {
 	"id": 6,
-	"name": "Closer to the Stars"
+	"name": "Closer to the Stars",
+	"achievement": 42 // references /v2/achievements
 }
 
 // GET /v2/titles?ids=6,7
@@ -17,10 +18,12 @@
 [
 	{
 		"id": 6,
-		"name": "Closer to the Stars"
+		"name": "Closer to the Stars",
+		"achievement" : 42
 	},
 	{
 		"id": 7,
-		"name": "Ghostly Hero"
+		"name": "Ghostly Hero",
+		"achievement": 43
 	}
 ]

--- a/v2/titles.js
+++ b/v2/titles.js
@@ -1,0 +1,26 @@
+// Normal bulk-expanded endpoint; supports localization.
+// GET /v2/titles
+
+[ 1, 2, 3, ... ]
+
+// GET /v2/titles/6
+// GET /v2/titles?id=6
+
+{
+	"id": 6,
+	"name": "Closer to the Stars"
+}
+
+// GET /v2/titles?ids=6,7
+// GET /v2/titles?page_size=2&page=0
+
+[
+	{
+		"id": 6,
+		"name": "Closer to the Stars"
+	},
+	{
+		"id": 7,
+		"name": "Ghostly Hero"
+	}
+]


### PR DESCRIPTION
Supercedes #258 -- the title names are localized, so they need to reference a localized endpoint (this might be a moot point since `/v2/achievements` is already localized -- it's totally possible to put the title name directly in the achievement). It's kind of bikeshedding on my part but I think it's better with the id in there. Let me know if you have an opinion either way -- the backend support for this won't be in until the release after next.

Refs #268.