### PR TITLE
Add world linking support to /v2/wvw/matches.

### DIFF
--- a/v2/wvw/matches.json
+++ b/v2/wvw/matches.json
@@ -88,6 +88,5 @@
 //    with /v1/guild_details.json.
 //  * Upgrades can be determined by checking last_flipped and claimed_at
 //    (since they'll be time-based at some point in the future).
-//  * match.all_worlds is omitted if there are no active merges.
 //  * ?world=X will always return the correct match, but the requested
 //    world may not be in match.worlds due to merges.

--- a/v2/wvw/matches.json
+++ b/v2/wvw/matches.json
@@ -28,6 +28,11 @@
 		"blue"  : 1002,
 		"green" : 1003
 	},
+	"all_worlds"  : {
+		"red"   : [ 1001, 1004 ],
+		"blue"  : [ 1002 ],
+		"green" : [ 1003 ]
+	},
 	"maps" : [
 		{
 			"id"         : 98,
@@ -83,3 +88,6 @@
 //    with /v1/guild_details.json.
 //  * Upgrades can be determined by checking last_flipped and claimed_at
 //    (since they'll be time-based at some point in the future).
+//  * match.all_worlds is omitted if there are no active merges.
+//  * ?world=X will always return the correct match, but the requested
+//    world may not be in match.worlds due to merges.


### PR DESCRIPTION
The current implementation omits `all_worlds` if there are no merges for the match. I'm thinking that this might be a mistake (might be easier to always have `all_worlds` even if there are no merges).