### PR TITLE
Add "required_access" to /v2/achievements.

### DIFF
--- a/v2/achievements/categories.js
+++ b/v2/achievements/categories.js
@@ -29,6 +29,7 @@
 		"order": 30,
 		"icon": "https://render.guildwars2.com/...",
 		"achievements": [1, 5, 4, 6, ...] 
+		"required_access": ["GuildWars2", "HeartOfThorns"]
 	},
 	{
 		"id": 2,
@@ -37,8 +38,12 @@
 		"order": 40,
 		"icon": "https://render.guildwars2.com/...",
 		"achievements": [134, 9, 137, ...]
+		"required_access": ["GuildWars2", "HeartOfThorns"]
 	}
 ]
 
-// "achievements" references /v2/achievements.
-// "order" is used for sorting in the UI.
+// * "achievements" references /v2/achievements.
+// * "order" is used for sorting in the UI.
+// * "required_access" references the "access" field of /v2/account. You'll
+//   only see achievements in-game which have an entry in required_access
+//   which matches your access.


### PR DESCRIPTION
This is mostly to handle the HoT/non-HoT split for daily achievements.

Mostly this applies to daily achievements -- not sure anything else is using this functionality -- but it can technically be applied to any category. I'm not entirely set on the functionality; it may make more sense to only emit `required_access` when it actually applies (e.g., when an achievement is only available to `GuildWars2` access or only to `HeartOfThorns` access). Also it would be nice to have this in `/v2/achievements` instead of in the categories, maybe (though the data is stored in the categories).

refs #291