### PR TITLE
Copy fractal category to /v2/achievements/daily

### DIFF
--- a/v2/achievements/daily.js
+++ b/v2/achievements/daily.js
@@ -26,6 +26,23 @@
 		...
 	],
 	special : [
+	],
+	fractal : [
+		{
+			id : 24,
+			level : {
+				min: 80,
+				max: 80
+			}
+		},
+		{
+			id : 26,
+			level : {
+				min: 80,
+				max: 80
+			}
+		}
+		// etc.
 	]
 }
 
@@ -37,3 +54,7 @@
 
 // "special" is for temporary content, mostly festival dailies
 // and the like. If there's no temporary content, [] is returned.
+
+// "fractal" is kind of weird; it's not strictly a "daily" but 
+// instead is actually achievement category 88. It's duplicated
+// here for convenience.


### PR DESCRIPTION
We can stuff additional fields (tier/scales/etc) into the achievement objects in the list in a separate PR; I think that keeping it within this structure is the most forwards-compatible format.

([forum ref](https://forum-en.guildwars2.com/forum/community/api/Fractal-dailies-for-tomorrow))
