### PR TITLE
Add /v2/pvp/ranks

### DIFF
--- a/v2/achievements/ranks.js
+++ b/v2/achievements/ranks.js
@@ -1,0 +1,23 @@
+// Normal bulk-expanded endpoint
+// GET /v2/pvp/ranks
+
+[ 1, 2, 3, ... ]
+
+// GET /v2/pvp/ranks/6
+// GET /v2/pvp/ranks?id=6
+
+{
+	"id": 6,
+	"title": "Rabbit",
+	"icon": "",
+	"points_required": 1500,
+	"points_total": 3500,
+}
+
+// GET /v2/pvp/ranks?ids=6,7
+
+[ /* rank 6 */, /* rank 7 */ ]
+
+// GET /v2/pvp/ranks?page=0&page_size=2
+
+[ /* rank 1 */, /* rank 2 */ ]


### PR DESCRIPTION
Exposes localized PvP rank titles to directly look up `pvp_rank` from /v2/pvp/stats and get the name, icon (i.e. [rabbit](https://wiki.guildwars2.com/wiki/File:Rabbit_rank.png)) and the points required to get to the next rank.

gitter ref: https://gitter.im/arenanet/api-cdi?at=57e6ed17240a335f12ea3f46