### PR TITLE
/v2/wvw/matches: add more objective fields.

### DIFF
--- a/v2/wvw/matches.json
+++ b/v2/wvw/matches.json
@@ -64,10 +64,10 @@
 					"owner"          : "Red",
 					"last_flipped"   : "2015-09-18T18:12:29Z",
 					"claimed_by"     : "5AE7196D-F62F-E511-B0A0-0862664D7672",
-					"claimed_at"     : "2015-09-18T18:12:44Z"
+					"claimed_at"     : "2015-09-18T18:12:44Z",
 					"points_tick"    : 2,
 					"points_capture" : 2,
-					"upgrades"       : [123, 134],
+					"guild_upgrades" : [123, 134],
 					"yaks_delivered" : 24
 				},
 				{
@@ -77,7 +77,7 @@
 					"claimed_by"   : null,
 					"claimed_at"   : null,
 					"points_tick"    : 2,
-					"points_capture" : 2,
+					"points_capture" : 2
 				},
 				...
 			]
@@ -94,6 +94,6 @@
 //    with /v1/guild_details.json.
 //  * ?world=X will always return the correct match, but the requested
 //    world may not be in match.worlds due to merges.
-//  * maps.N.objectives.M.upgrades refers to /v2/guild/upgrades.
+//  * maps.N.objectives.M.guild_upgrades refers to /v2/guild/upgrades.
 //  * maps.N.objectives.M.yaks_delivered is the total number of supply
 //    shipments (not just within the current upgrade tier).

--- a/v2/wvw/matches.json
+++ b/v2/wvw/matches.json
@@ -92,8 +92,6 @@
 //  * maps.N.objectives.M.id references /v2/wvw/objectives.
 //  * maps.N.objectives.M.claimed_by is a guild GUID that can be resolved
 //    with /v1/guild_details.json.
-//  * Upgrades can be determined by checking last_flipped and claimed_at
-//    (since they'll be time-based at some point in the future).
 //  * ?world=X will always return the correct match, but the requested
 //    world may not be in match.worlds due to merges.
 //  * maps.N.objectives.M.upgrades refers to /v2/guild/upgrades.

--- a/v2/wvw/matches.json
+++ b/v2/wvw/matches.json
@@ -67,7 +67,8 @@
 					"claimed_at"     : "2015-09-18T18:12:44Z"
 					"points_tick"    : 2,
 					"points_capture" : 2,
-					"upgrades"       : [123, 134]
+					"upgrades"       : [123, 134],
+					"yaks_delivered" : 24
 				},
 				{
 					"id"           : "98-103",
@@ -96,3 +97,5 @@
 //  * ?world=X will always return the correct match, but the requested
 //    world may not be in match.worlds due to merges.
 //  * maps.N.objectives.M.upgrades refers to /v2/guild/upgrades.
+//  * maps.N.objectives.M.yaks_delivered is the total number of supply
+//    shipments (not just within the current upgrade tier).

--- a/v2/wvw/matches.json
+++ b/v2/wvw/matches.json
@@ -60,18 +60,23 @@
 			},
 			"objectives" : [
 				{
-					"id"           : "98-102",
-					"owner"        : "Red",
-					"last_flipped" : "2015-09-18T18:12:29Z",
-					"claimed_by"   : "5AE7196D-F62F-E511-B0A0-0862664D7672",
-					"claimed_at"   : "2015-09-18T18:12:44Z"
+					"id"             : "98-102",
+					"owner"          : "Red",
+					"last_flipped"   : "2015-09-18T18:12:29Z",
+					"claimed_by"     : "5AE7196D-F62F-E511-B0A0-0862664D7672",
+					"claimed_at"     : "2015-09-18T18:12:44Z"
+					"points_tick"    : 2,
+					"points_capture" : 2,
+					"upgrades"       : [123, 134]
 				},
 				{
 					"id"           : "98-103",
 					"owner"        : "Red",
 					"last_flipped" : "2015-09-18T18:12:29Z",
 					"claimed_by"   : null,
-					"claimed_at"   : null
+					"claimed_at"   : null,
+					"points_tick"    : 2,
+					"points_capture" : 2,
 				},
 				...
 			]
@@ -90,3 +95,4 @@
 //    (since they'll be time-based at some point in the future).
 //  * ?world=X will always return the correct match, but the requested
 //    world may not be in match.worlds due to merges.
+//  * maps.N.objectives.M.upgrades refers to /v2/guild/upgrades.


### PR DESCRIPTION
 * points_capture/points_tick since points are variable now.
 * upgrades containing a list of slotted upgrades.

I'm not altogether happy with the output format, very open to suggestions.

Fixes #181; ~doesn't yet expose yaks needed for next tier~.
Fixes #394.
Refs #118. Localized upgrade stuff (and the yaks/tier) needs to be added somewhere.