### PR TITLE
Add sub-endpoints for /v2/wvw/matches.

### DIFF
--- a/v2/wvw/matches-overview.js
+++ b/v2/wvw/matches-overview.js
@@ -1,0 +1,32 @@
+// Bulk-expanded sub-endpoint which returns the mostly-static overview
+// data from /v2/wvw/matches.
+
+// GET /v2/wvw/matches/overview
+
+[ "1-1", "1-2" ]
+
+// GET /v2/wvw/matches/overview/1-1
+
+{
+  "id": "1-1",
+  "worlds": {
+    "red": 1008,
+    "blue": 1007,
+    "green": 1001
+  },
+  "all_worlds": {
+    "red": [
+      1008
+    ],
+    "blue": [
+      1007
+    ],
+    "green": [
+      1005,
+      1006,
+      1001
+    ]
+  },
+  "start_time": "2016-12-21T17:21:00Z",
+  "end_time": "2016-12-21T19:21:00Z"
+}

--- a/v2/wvw/matches-overview.js
+++ b/v2/wvw/matches-overview.js
@@ -1,11 +1,13 @@
 // Bulk-expanded sub-endpoint which returns the mostly-static overview
-// data from /v2/wvw/matches.
+// data from /v2/wvw/matches. The ?world parameter may be used to select
+// the matchup for a given world.
 
 // GET /v2/wvw/matches/overview
 
 [ "1-1", "1-2" ]
 
 // GET /v2/wvw/matches/overview/1-1
+// GET /v2/wvw/matches/overview?world=1008
 
 {
   "id": "1-1",

--- a/v2/wvw/matches-scores.js
+++ b/v2/wvw/matches-scores.js
@@ -1,11 +1,13 @@
 // Bulk-expanded sub-endpoint of /v2/wvw/matches. Provides access to
-// just the score fields.
+// just the score fields. The ?world parameter may be used to select
+// a match by world id.
 
 // GET /v2/wvw/matches/scores
 
 [ "1-1", "1-2" ]
 
 // GET /v2/wvw/matches/scores/1-1
+// GET /v2/wvw/matches/scores?world=1008
 
 {
   "id": "1-1",

--- a/v2/wvw/matches-scores.js
+++ b/v2/wvw/matches-scores.js
@@ -1,0 +1,28 @@
+// Bulk-expanded sub-endpoint of /v2/wvw/matches. Provides access to
+// just the score fields.
+
+// GET /v2/wvw/matches/scores
+
+[ "1-1", "1-2" ]
+
+// GET /v2/wvw/matches/scores/1-1
+
+{
+  "id": "1-1",
+  "scores": {
+    "red": 48,
+    "blue": 48,
+    "green": 48
+  },
+  "maps": [
+    {
+      "id": 38,
+      "type": "Center",
+      "scores": {
+        "red": 48,
+        "blue": 48,
+        "green": 48
+      }
+    }
+  ]
+}

--- a/v2/wvw/matches-stats.js
+++ b/v2/wvw/matches-stats.js
@@ -1,0 +1,37 @@
+// Bulk-expanded subset of /v2/matches.
+
+// GET /v2/wvw/matches/stats
+
+[ "1-1", "1-2" ]
+
+// GET /v2/wvw/matches/stats/1-1
+
+{
+  "id": "1-1",
+  "deaths": {
+    "green": 0,
+    "blue": 0,
+    "red": 0
+  },
+  "kills": {
+    "green": 0,
+    "blue": 0,
+    "red": 0
+  },
+  "maps": [
+    {
+      "id": 38,
+      "type": "Center",
+      "deaths": {
+        "green": 0,
+        "blue": 0,
+        "red": 0
+      },
+      "kills": {
+        "green": 0,
+        "blue": 0,
+        "red": 0
+      }
+    }
+  ]
+}

--- a/v2/wvw/matches-stats.js
+++ b/v2/wvw/matches-stats.js
@@ -1,10 +1,13 @@
-// Bulk-expanded subset of /v2/matches.
+// Bulk-expanded subset of /v2/matches. Contains KDR and any other
+// statistics we add in. The ?world parameter may be used to select
+// a match by world id.
 
 // GET /v2/wvw/matches/stats
 
 [ "1-1", "1-2" ]
 
 // GET /v2/wvw/matches/stats/1-1
+// GET /v2/wvw/matches/stats?world=1008
 
 {
   "id": "1-1",


### PR DESCRIPTION
Three endpoints:

 * /v2/wvw/matches/overview provides mostly static match data.
 * /v2/wvw/matches/scores contains the total and per-map scores.
 * /v2/wvw/matches/stats has the total and per-map KDR bits.

Objective data is the bulk of the payload and can be fetched with the main
endpoint, /v2/wvw/matches.

Addresses most of the points in #412, but doesn't provide `?maps=`
parameter; these response sizes didn't seem large enough to warrant it.