### PR TITLE
Add region selections to PvP leaderboards.

### DIFF
--- a/v2/pvp/season-leaderboards.js
+++ b/v2/pvp/season-leaderboards.js
@@ -7,10 +7,16 @@
 // which have slightly different outputp formats (since one's for
 // individual users and the other is for guild teams).
 //
+// "na" or "eu" should be appended after the leaderboard to switch 
+// between regions; for backwards-compat the region can be omitted to
+// use the "local" region (e.g. "na" if you're talking to the NA
+// datacenter, "eu" for the EU datacenter -- this is switched via
+// geographic DNS resolution).
+//
 // Endpoints can be paginated with ?page_size and ?page query parameters.
 // They should additionally emit pagination-related headers.
 
-// GET /v2/pvp/seasons/:id/leaderboards/legendary
+// GET /v2/pvp/seasons/:id/leaderboards/legendary/na
 
 [
 	{
@@ -26,7 +32,7 @@
 	}
 ]
 
-// GET /v2/pvp/seasons/:id/leaderboards/guild
+// GET /v2/pvp/seasons/:id/leaderboards/guild/eu
 
 [
 	{


### PR DESCRIPTION
Fixes #427 

This fixes it in the backwards-compatible way: the old requests will default to whatever datacenter you happen to be talking to, but you can now append `/na` or `/eu` to the request to get the leaderboard for wherever you want.

Hooray.