### PR TITLE
Require a region to be specified for leaderboards.

### DIFF
--- a/v2/pvp/season-leaderboards.js
+++ b/v2/pvp/season-leaderboards.js
@@ -7,16 +7,17 @@
 // which have slightly different outputp formats (since one's for
 // individual users and the other is for guild teams).
 //
-// "na" or "eu" should be appended after the leaderboard to switch 
-// between regions; for backwards-compat the region can be omitted to
-// use the "local" region (e.g. "na" if you're talking to the NA
-// datacenter, "eu" for the EU datacenter -- this is switched via
-// geographic DNS resolution).
+// The region field of the URL cannot be omitted and must be either
+// "na" or "eu".
 //
 // Endpoints can be paginated with ?page_size and ?page query parameters.
 // They should additionally emit pagination-related headers.
 
-// GET /v2/pvp/seasons/:id/leaderboards/legendary/na
+// GET /v2/pvp/seasons/:id/leaderboards/legendary
+
+[ "na", "eu" ]
+
+// GET /v2/pvp/seasons/:id/leaderboards/legendary/:region
 
 [
 	{
@@ -32,7 +33,7 @@
 	}
 ]
 
-// GET /v2/pvp/seasons/:id/leaderboards/guild/eu
+// GET /v2/pvp/seasons/:id/leaderboards/guild/:region
 
 [
 	{


### PR DESCRIPTION
This is a breaking change (leaderboards previously didn't require a region
field -- which returned one region or the other depending on which
datacenter your request was routed to). The old behavior doesn't make much
sense but was maintained just in case someone was depending on it. This
removes that backwards compat.

Planning on deploying this in two weeks, on January 25, 2017.