### PR TITLE
Add the current map id to the mumble link data.

### DIFF
--- a/mumble.md
+++ b/mumble.md
@@ -8,6 +8,7 @@
 	"world_id": 1001,
 	"team_color_id": 0,
 	"commander": false,
+	"map": 50, // current map id
 	"fov": 0.873 // vertical fov
 }
 // Where profession values have the following mapping:


### PR DESCRIPTION
I meant to add `floor_id` but I got confused.

Well, whatever.