### PR TITLE
Add .skills to /v2/professions.

### DIFF
--- a/v2/professions.js
+++ b/v2/professions.js
@@ -108,8 +108,38 @@
 			"specialization" : 12,
 			"skills" : [ /* ... */ ]
 		}
-	}
+	},
+	// List of all non-weapon skills that can be equipped by this
+	// profession (doesn't include transform skills and such).
+	"skills" : [
+		{
+			"id"   : 34,
+			"slot" : "Profession_1",
+			"type" : "Profession"
+		},
+		{
+			"id"   : 45,
+			"slot" : "Utility",
+			"type" : "Utility"
+		},
+		{
+			"id"   : 98,
+			"slot" : "Heal",
+			"type" : "Heal"
+		},
+		{
+			"id"   : 102,
+			"slot" : "Elite",
+			"type" : "Elite"
+		}
+	],
+	"flags" : []
 }
+
+// NOTES:
+//  * flags may currently contain:
+//     - "NoRacialSkills": this profession cannot equip racial skills.
+//     - "NoWeaponSwap": this profession can only use one weapon set.
 
 // Can also fetch multiple professions via bulk-expanded options, e.g.
 //


### PR DESCRIPTION
Rather than enumerating `.training`, this should pick up all the skills that can be equipped that aren't weapon skills. Also mungling this up is a new `.flags` field which has some boring static data.

This first pass doesn't include things like specialization requirements; will add that in a separate feature.