### PR TITLE
Add raid/dungeon progress endpoints.

### DIFF
--- a/v2/account/dungeons.js
+++ b/v2/account/dungeons.js
@@ -1,0 +1,7 @@
+// Authenticated endpoint that returns the account's daily dungeon
+// completions. Requires the "progression" permission. Returned values
+// correspond with path ids from /v2/dungeons.
+
+// GET /v2/account/dungeons?access_token=foo
+
+[ "hodgins", "seraph", "seer" ]

--- a/v2/account/raids.js
+++ b/v2/account/raids.js
@@ -1,0 +1,7 @@
+// Authenticated endpoint that returns the account's weekly raid
+// progress. Requires "progression" scope. Returned keys correspond
+// with the event ids from /v2/raids.
+
+// GET /v2/account/raids?access_token=foo
+
+[ "gorseval", "xera" ]

--- a/v2/dungeons.js
+++ b/v2/dungeons.js
@@ -1,0 +1,31 @@
+// Normal bulk-expanded endpoint; has string keys, supports ?ids=all.
+
+// GET /v2/dungeons
+
+[ "ascalonian_catacombs", "cadecus_manor", ... ]
+
+// GET /v2/dungeons/twilight_arbor
+// GET /v2/dungeons?id=twilight_arbor
+
+{
+	"id" : "twilight_arbor",
+	"paths" : [
+		"leurent",
+		"vevina",
+		"aetherpath"
+	]
+}
+
+// GET /v2/dungeons?ids=twilight_arbor
+// GET /v2/dungeons?page=0&page_size=1
+
+[
+	{
+		"id" : "twilight_arbor",
+		"paths" : [
+			"leurent",
+			"vevina",
+			"aetherpath"
+		]
+	}
+]

--- a/v2/raids.js
+++ b/v2/raids.js
@@ -1,0 +1,34 @@
+// Normal bulk-expanded endpoint with string keys.
+
+// GET /v2/raids
+
+[ "forsaken_thicket" ]
+
+// GET /v2/raids?id=forsaken_thicket
+// GET /v2/raids/forsaken_thicket
+
+{
+	"id" : "forsaken_thicket",
+	"wings" : [{
+		"id" : "spirit_vale",
+		"events" : [{
+			"id" : "vale_guardian",
+			"type" : "Boss"
+		}, {
+			"id" : "spirit_woods",
+			"type" : "Checkpoint"
+		}, {
+			"id" : "gorseval",
+			"type" : "Boss"
+		}, {
+			"id" : "sabetha",
+			"type" : "Boss"
+		}]
+	}]
+}
+
+// GET /v2/raids?ids=forsaken_thicket
+// GET /v2/raids?ids=all
+// GET /v2/raids?page=0&page_size=1
+
+[ { "id" : "forsaken_thicket" }, ... ]


### PR DESCRIPTION
 * /v2/raids
 * /v2/account/raids
 * /v2/dungeons
 * /v2/account/dungeons

The data for the unauthenticated endpoints right now just exposes the bare
minimum; we can expand it with a future pull request.

Fixes #434