### PR TITLE
First-pass at some bulk-expanded story endpoints.

### DIFF
--- a/v2/journal/episodes.js
+++ b/v2/journal/episodes.js
@@ -1,0 +1,37 @@
+// Bulk-expanded endpoint that provides access to journal story episodes.
+
+// GET /v2/journal/episodes
+
+[ 1, 2, 3 ]
+
+// GET /v2/journal/episodes/1
+// GET /v2/journal/episodes?id=1
+
+{
+	"id" : 1,
+	"name" : "My Story",
+	"description" : "",
+	"timeline" : "1325 AE",
+	"required_level" : 1,
+	"required_race" : "Charr",
+	"season" : "215AAA0F-CDAC-4F93-86DA-C155A99B5784",
+	"sort" : 0,
+	"chapters" : [
+		{
+			"name" : "1. Getting the Band Back Together"
+		},
+		{
+			"name" : "2. Sins of the Father"
+		},
+		{
+			"name" : "3. Crystal Corruption"
+		}
+	]
+}
+
+// GET /v2/journal/episodes?ids=1
+// GET /v2/journal/episodes?page=0&page_size=1
+
+[
+	{ /* episode 1 */ }
+]

--- a/v2/journal/stories.js
+++ b/v2/journal/stories.js
@@ -1,0 +1,37 @@
+// Bulk-expanded endpoint that provides access to the journal stories.
+// Each "season" is a story in this sense.
+
+// GET /v2/journal/stories
+
+[
+	"215AAA0F-CDAC-4F93-86DA-C155A99B5784",
+	"67F0AE11-A58F-422F-8BB8-1B0F3948078A",
+	// ...
+]
+
+// GET /v2/journal/stories/215AAA0F-CDAC-4F93-86DA-C155A99B5784
+// GET /v2/journal/stories?id=215AAA0F-CDAC-4F93-86DA-C155A99B5784
+
+{
+	"id" : "215AAA0F-CDAC-4F93-86DA-C155A99B5784",
+	"name" : "My Story",
+	"description" : "",
+	"sort" : 1,
+	"episode" : [
+		2, 7, 8, 3, // ...
+	]
+}
+
+// GET /v2/journal/stories?page=0&page_size=200
+// GET /v2/journal/stories?ids=all
+// GET /v2/journal/stories?ids=215AAA0F-CDAC-4F93-86DA-C155A99B5784,...
+
+[
+	{ /* story 1 */ },
+	{ /* story 2 */ },
+	// ...
+]
+
+// NOTES:
+//   * story.episode[n] has ids that can be referenced against 
+//     /v2/journal/episode.


### PR DESCRIPTION
Right now the chapters section is a bit bare -- there's not much metadata
the backend service currently exposes for these. Will probably add the
chapter rewards and locations (and maybe event metadata, if I have the
courage to dig that out) as part of a future pull request.

This also kindly omits the account side of things for exposing which
chapters have been completed (which is on a per-character basis). This is
a bit more finicky because the personal story is branching -- not entirely
certain how to best express that.

Finally, on a related note, the relations between chapters is currently
pretty vague (e.g., that only one of the orders can be selected). Still
need to figure out how to express that in a coherent way.