### PR TITLE
Fix guild emblem format

### DIFF
--- a/v2/guild/details.js
+++ b/v2/guild/details.js
@@ -12,7 +12,7 @@
         },
         "foreground": {
             "id": 114,
-                "colors": [584, 64]
+            "colors": [584, 64]
         },
         "flags": []
     }

--- a/v2/guild/details.js
+++ b/v2/guild/details.js
@@ -8,7 +8,7 @@
     "emblem": {
         "background": {
             "id": 27,
-                "colors": [11]
+            "colors": [11]
         },
         "foreground": {
             "id": 114,

--- a/v2/guild/details.js
+++ b/v2/guild/details.js
@@ -2,15 +2,18 @@
 
 // GET v2/guilds/:id
 {
-   "id": "75FD83CF-0C45-4834-BC4C-097F93A487AF",
-   "name": "Veterans Of Lions Arch",
-   "tag": "LA",
-   "emblem": {
-     "background": 27,
-     "foreground": 114,
-     "flags": [],
-     "background_color": 11,
-     "foreground_primary_color": 584,
-     "foreground_secondary_color": 64
-   }
- }
+    "id": "75FD83CF-0C45-4834-BC4C-097F93A487AF",
+    "name": "Veterans Of Lions Arch",
+    "tag": "LA",
+    "emblem": {
+        "background": {
+            "id": 27,
+                "colors": [11]
+        },
+        "foreground": {
+            "id": 114,
+                "colors": [584, 64]
+        },
+        "flags": []
+    }
+}


### PR DESCRIPTION
Following comments in #257 and what's currently live. I don't think it has ever been different after this endpoint's release.