### PR TITLE
Add character’s experience and level-up threshold to /characters

### DIFF
--- a/v2/characters/characters.js
+++ b/v2/characters/characters.js
@@ -190,12 +190,21 @@
 // Scopes: account, characters, progression
 //
 // With the progression permission, the following fields are added:
+//  * experience: current absolute amount of experience as well as the numbers
+//    required to reach the current and the next level. Once the character
+//    reached level 80, current and this_level will stay at the maximum
+//    (currently 4860359), while next_level will change to false.
 //  * wvw_abilities. Note that ranks are 1-indexed, so rank=1 means
 //    that ability.ranks[0] is unlocked, but not ability.ranks[1].
 //
 {
 	name: "Hello",
 	// Other fields.
+	experience: {
+		current: 123456,
+		this_level: 1168459,
+		next_level: 1236659
+	},
 	wvw_abilities: [
 		{ id: 2, rank: 5 },
 		{ id: 3, rank: 1 }


### PR DESCRIPTION
I love tracking a character’s progress over time, and I’m already able to retrieve the wallet, inventory and level. However, in higher levels it takes a large amount of time to reach the next one. Therefore I think it would be useful to be able to track the experience bar of a character.

I’m proposing three new values that are available via `/characters` if the token has `progression` permission:

```javascript
{ experience: {
  current: 123456,
  this_level: 1168459,
  next_level: 1236659
}}
```

 These allow you to retrieve the current absolute amount of experience as well as the amount required to reach the current and the next level.

You can use these to calculate an XP bar percentage: `(current - next_level) / (next_level - this_level) * 100`.

Once a character reaches level 80, XP gained will instead count towards masteries (if the player owns HoT/PoF), which is out of scope for this PR. `current` and `this_level` will then stay the same number (maximum XP, currently 4,860,359), while `next_level` will change to `false`, meaning that there is no next level.

An alternative way to implement this would be to just return a single number for `experience`, without providing `this_level` or `next_level`. Applications would then need to consult the [XP table](https://wiki.guildwars2.com/wiki/Experience#Total_experience_gain_per_level) or a (not yet implemented) separate endpoint providing it. This would be easier to implement on the server side, but harder for clients.