### PR TITLE
Add missing "name" tag to /v2/races

### DIFF
--- a/v2/races.js
+++ b/v2/races.js
@@ -10,6 +10,7 @@
 
 {
 	"id" : "Human",
+	"name": "Human",
 	"skills" : [ 1, 2, 3, ... ]
 }
 
@@ -19,6 +20,7 @@
 [
 	{
 		"id" : "Human",
+		"name": "Human",
 		"skills" : [ 1, 2, 3, ... ]
 	},
 	...


### PR DESCRIPTION
**This is a documentation fix, not a feature request.**

The current documentation of /v2/races is missing the "name" tag.

### Example
`https://api.guildwars2.com/v2/races?id=Human`

```
{
  "id": "Human",
  "name": "Human",
  "skills": [
    12360,
    12361,
    12362,
    12363,
    12367,
    12373,
    10800
  ]
}
```