### PR TITLE
Add floorId to MumbleLink

### DIFF
--- a/mumble.md
+++ b/mumble.md
@@ -28,7 +28,11 @@
 // Just raw bytes.
 struct MumbleContext {
     byte serverAddress[28]; // contains sockaddr_in or sockaddr_in6
-    unsigned mapId;
+	unsigned continentId;
+	unsigned regionId;
+	unsigned mapId;
+	unsigned floorId;
+	unsigned sectorId;
     unsigned mapType;
     unsigned shardId;
     unsigned instance;

--- a/mumble.md
+++ b/mumble.md
@@ -28,11 +28,11 @@
 // Just raw bytes.
 struct MumbleContext {
     byte serverAddress[28]; // contains sockaddr_in or sockaddr_in6
-	unsigned continentId;
-	unsigned regionId;
-	unsigned mapId;
-	unsigned floorId;
-	unsigned sectorId;
+    unsigned continentId;
+    unsigned regionId;
+    unsigned mapId;
+    unsigned floorId;
+    unsigned sectorId;
     unsigned mapType;
     unsigned shardId;
     unsigned instance;


### PR DESCRIPTION
Add ``continentId > regionId > floorId > sectorId`` to the mumble link context struct supporting and reducing queries to the very complex v2/continents endpoint.

As discussed in PR #2 floor ids from the API differ per map and are arbitrary! We do not have enough information about the player's coordinates to calculate the current floor. . Current floor detection is impossible and thus current sector detection BREAKS on maps with sectors lying ontop of each other.
The floor id is useful to have for popular marker utility tools possibly increasing performance by restricting loading markers for the floor the player is currently on but also for gimmicks such as showing nameplates of entering a sector: https://gfycat.com/CompetentReadyGilamonster

I've added continentId > regionId > sectorId to have the complete hierarchical structure of Tyria because I believe it would be not big of a deal to just add these while we have still a lot of space in the context structure (85/256 bytes of the context structure are currently in use I believe). 

Example of v2/continents endpoint as reference to how messy it can get:
```
https://api.guildwars2.com/v2/continents/<continentId>/floors/<floorId>/regions/<regionId>/maps/<mapId>/sectors?ids=all
```
=
```https://api.guildwars2.com/v2/continents/1/floors/1/regions/4/maps/15/sectors?ids=all```